### PR TITLE
Add test case to make sure normalization works on deobfuscated SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,6 @@ func main() {
 
 ### Normalize
 
-**Note**: By design, normalization works on obfuscated queries.
-
 ```go
 import (
     "fmt"


### PR DESCRIPTION
This PR adds test case to make sure normalization works on deobfuscated SQL. This is an important feature to allow users to opt out obfuscation before normalization runs