### PR TITLE
optional obfuscate positional params, booleans and null

### DIFF
--- a/obfuscator.go
+++ b/obfuscator.go
@@ -99,27 +99,25 @@ func (o *Obfuscator) ObfuscateTokenValue(token Token, lexerOpts ...lexerOption) 
 		}
 	case STRING, INCOMPLETE_STRING, DOLLAR_QUOTED_STRING:
 		return StringPlaceholder
-  case POSITIONAL_PARAMETER:
-    if o.config.ReplacePositionalParameter {
-      obfuscatedSQL.WriteString(StringPlaceholder)
-    } else {
-      obfuscatedSQL.WriteString(token.Value)
-    }
+	case POSITIONAL_PARAMETER:
+		if o.config.ReplacePositionalParameter {
+			return StringPlaceholder
+		} else {
+			return token.Value
+		}
 	case IDENT:
 		if o.config.ReplaceBoolean && isBoolean(token.Value) {
-      obfuscatedSQL.WriteString(StringPlaceholder)
-      continue
-    }
-    if o.config.ReplaceNull && isNull(token.Value) {
-      obfuscatedSQL.WriteString(StringPlaceholder)
-      continue
-    }
+			return StringPlaceholder
+		}
+		if o.config.ReplaceNull && isNull(token.Value) {
+			return StringPlaceholder
+		}
 
-    if o.config.ReplaceDigits {
-      obfuscatedSQL.WriteString(replaceDigits(token.Value, "?"))
-    } else {
-      obfuscatedSQL.WriteString(token.Value)
-    }
+		if o.config.ReplaceDigits {
+			return replaceDigits(token.Value, "?")
+		} else {
+			return token.Value
+		}
 	default:
 		return token.Value
 	}

--- a/sqllexer.go
+++ b/sqllexer.go
@@ -17,7 +17,7 @@ const (
 	PUNCTUATION            // punctuation
 	DOLLAR_QUOTED_FUNCTION // dollar quoted function
 	DOLLAR_QUOTED_STRING   // dollar quoted string
-	NUMBERED_PARAMETER     // numbered parameter
+	POSITIONAL_PARAMETER   // numbered parameter
 	UNKNOWN                // unknown token
 )
 
@@ -121,7 +121,7 @@ func (s *Lexer) Scan() Token {
 	case ch == '$':
 		if isDigit(s.lookAhead(1)) {
 			// if the dollar sign is followed by a digit, then it's a numbered parameter
-			return s.scanNumberedParameter()
+			return s.scanPositionalParameter()
 		}
 		if s.config.DBMS == DBMSSQLServer && isLetter(s.lookAhead(1)) {
 			return s.scanIdentifier()
@@ -393,7 +393,7 @@ func (s *Lexer) scanDollarQuotedString() Token {
 	return Token{ERROR, s.src[s.start:s.cursor]}
 }
 
-func (s *Lexer) scanNumberedParameter() Token {
+func (s *Lexer) scanPositionalParameter() Token {
 	s.start = s.cursor
 	ch := s.nextBy(2) // consume the dollar sign and the number
 	for {
@@ -402,7 +402,7 @@ func (s *Lexer) scanNumberedParameter() Token {
 		}
 		ch = s.next()
 	}
-	return Token{NUMBERED_PARAMETER, s.src[s.start:s.cursor]}
+	return Token{POSITIONAL_PARAMETER, s.src[s.start:s.cursor]}
 }
 
 func (s *Lexer) scanUnknown() Token {

--- a/sqllexer_test.go
+++ b/sqllexer_test.go
@@ -312,7 +312,7 @@ func TestLexer(t *testing.T) {
 				{WS, " "},
 				{OPERATOR, "="},
 				{WS, " "},
-				{NUMBERED_PARAMETER, "$1"},
+				{POSITIONAL_PARAMETER, "$1"},
 			},
 		},
 		{

--- a/sqllexer_utils.go
+++ b/sqllexer_utils.go
@@ -116,6 +116,14 @@ func isSQLKeyword(token Token) bool {
 	return token.Type == IDENT && keywordsRegex.MatchString(token.Value)
 }
 
+func isBoolean(ident string) bool {
+	return strings.ToUpper(ident) == "TRUE" || strings.ToUpper(ident) == "FALSE"
+}
+
+func isNull(ident string) bool {
+	return strings.ToUpper(ident) == "NULL"
+}
+
 func replaceDigits(input string, placeholder string) string {
 	var builder strings.Builder
 


### PR DESCRIPTION
This PR adds options to obfuscate positional params (e.g. `$1`, `$2`), booleans (`true/false`) and null