### PR TITLE
support mysql backtick quoted identifier

### DIFF
--- a/sqllexer.go
+++ b/sqllexer.go
@@ -138,6 +138,11 @@ func (s *Lexer) Scan() Token {
 			return s.scanBindParameter()
 		}
 		return s.scanOperator()
+	case ch == '`':
+		if s.config.DBMS == DBMSMySQL {
+			return s.scanDoubleQuotedIdentifier('`')
+		}
+		fallthrough
 	case isOperator(ch):
 		return s.scanOperator()
 	case isPunctuation(ch):

--- a/sqllexer_test.go
+++ b/sqllexer_test.go
@@ -536,6 +536,28 @@ func TestLexer(t *testing.T) {
 			},
 			lexerOpts: []lexerOption{WithDBMS(DBMSSQLServer)},
 		},
+		{
+			name:  "MySQL backtick quoted identifier",
+			input: "SELECT `user` FROM `test`.`table` WHERE `id` = 1",
+			expected: []Token{
+				{IDENT, "SELECT"},
+				{WS, " "},
+				{IDENT, "`user`"},
+				{WS, " "},
+				{IDENT, "FROM"},
+				{WS, " "},
+				{IDENT, "`test`.`table`"},
+				{WS, " "},
+				{IDENT, "WHERE"},
+				{WS, " "},
+				{IDENT, "`id`"},
+				{WS, " "},
+				{OPERATOR, "="},
+				{WS, " "},
+				{NUMBER, "1"},
+			},
+			lexerOpts: []lexerOption{WithDBMS(DBMSMySQL)},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR adds support to tokenize MySQL backtick quoted identifier, e.g.
```
Select `user` from `table`
```