### PR TITLE
Trim trailing semicolon

### DIFF
--- a/normalizer.go
+++ b/normalizer.go
@@ -125,7 +125,7 @@ func (n *Normalizer) Normalize(input string, lexerOpts ...lexerOption) (normaliz
 	// Dedupe collected metadata
 	dedupeStatementMetadata(statementMetadata)
 
-	return trimNormalizedSQL(normalizedSQL), statementMetadata, nil
+	return strings.TrimSpace(strings.TrimSuffix(normalizedSQL, ";")), statementMetadata, nil
 }
 
 func (n *Normalizer) collectMetadata(token *Token, lastToken *Token, statementMetadata *StatementMetadata) {
@@ -279,14 +279,4 @@ func appendWhitespace(lastToken *Token, token *Token, normalizedSQLBuilder *stri
 	default:
 		normalizedSQLBuilder.WriteString(" ")
 	}
-}
-
-func trimNormalizedSQL(input string) string {
-	// trim trailing semicolon
-	input = strings.TrimRight(input, ";")
-
-	// trim leading and trailing whitespace
-	input = strings.TrimSpace(input)
-
-	return input
 }

--- a/normalizer.go
+++ b/normalizer.go
@@ -125,7 +125,7 @@ func (n *Normalizer) Normalize(input string, lexerOpts ...lexerOption) (normaliz
 	// Dedupe collected metadata
 	dedupeStatementMetadata(statementMetadata)
 
-	return strings.TrimSpace(normalizedSQL), statementMetadata, nil
+	return trimNormalizedSQL(normalizedSQL), statementMetadata, nil
 }
 
 func (n *Normalizer) collectMetadata(token *Token, lastToken *Token, statementMetadata *StatementMetadata) {
@@ -279,4 +279,14 @@ func appendWhitespace(lastToken *Token, token *Token, normalizedSQLBuilder *stri
 	default:
 		normalizedSQLBuilder.WriteString(" ")
 	}
+}
+
+func trimNormalizedSQL(input string) string {
+	// trim trailing semicolon
+	input = strings.TrimRight(input, ";")
+
+	// trim leading and trailing whitespace
+	input = strings.TrimSpace(input)
+
+	return input
 }

--- a/normalizer_test.go
+++ b/normalizer_test.go
@@ -157,7 +157,7 @@ multiline comment */
 						SELECT * FROM users WHERE id = ?;
 						Update test_users set name = ? WHERE id = ?;
 						Delete FROM user? WHERE id = ?;
-					END
+					END;
 					`,
 			expected: "CREATE PROCEDURE test_procedure ( ) BEGIN SELECT * FROM users WHERE id = ? ; Update test_users set name = ? WHERE id = ? ; Delete FROM user? WHERE id = ? ; END",
 			statementMetadata: StatementMetadata{
@@ -222,7 +222,7 @@ multiline comment */
 					FROM cte
 					WHERE age <= ?;
 					`,
-			expected: "WITH cte AS ( SELECT id, name, age FROM person WHERE age > ? ) UPDATE person SET age = ? WHERE id IN ( SELECT id FROM cte ) ; INSERT INTO person ( name, age ) SELECT name, ? FROM cte WHERE age <= ? ;",
+			expected: "WITH cte AS ( SELECT id, name, age FROM person WHERE age > ? ) UPDATE person SET age = ? WHERE id IN ( SELECT id FROM cte ) ; INSERT INTO person ( name, age ) SELECT name, ? FROM cte WHERE age <= ?",
 			statementMetadata: StatementMetadata{
 				Tables:     []string{"person", "cte"},
 				Comments:   []string{},
@@ -839,7 +839,7 @@ func TestNormalizerStoredProcedure(t *testing.T) {
 				SELECT * FROM users WHERE id = id;
 			END;
 			`,
-			expected: "CREATE PROCEDURE TestProcedure ( id INT ) BEGIN SELECT * FROM users WHERE id = id ; END ;",
+			expected: "CREATE PROCEDURE TestProcedure ( id INT ) BEGIN SELECT * FROM users WHERE id = id ; END",
 			statementMetadata: StatementMetadata{
 				Tables:     []string{"users"},
 				Comments:   []string{},
@@ -855,7 +855,7 @@ func TestNormalizerStoredProcedure(t *testing.T) {
 				UPDATE users SET name = 'test' WHERE id = id;
 			END;
 			`,
-			expected: "CREATE PROC TestProcedure ( id INT ) BEGIN UPDATE users SET name = 'test' WHERE id = id ; END ;",
+			expected: "CREATE PROC TestProcedure ( id INT ) BEGIN UPDATE users SET name = 'test' WHERE id = id ; END",
 			statementMetadata: StatementMetadata{
 				Tables:     []string{"users"},
 				Comments:   []string{},
@@ -871,7 +871,7 @@ func TestNormalizerStoredProcedure(t *testing.T) {
 				DELETE FROM users WHERE id = id;
 			END;
 			`,
-			expected: "CREATE OR REPLACE PROCEDURE TestProcedure ( id INT ) BEGIN DELETE FROM users WHERE id = id ; END ;",
+			expected: "CREATE OR REPLACE PROCEDURE TestProcedure ( id INT ) BEGIN DELETE FROM users WHERE id = id ; END",
 			statementMetadata: StatementMetadata{
 				Tables:     []string{"users"},
 				Comments:   []string{},

--- a/obfuscate_and_normalize.go
+++ b/obfuscate_and_normalize.go
@@ -37,5 +37,5 @@ func ObfuscateAndNormalize(input string, obfuscator *Obfuscator, normalizer *Nor
 	// Dedupe collected metadata
 	dedupeStatementMetadata(statementMetadata)
 
-	return trimNormalizedSQL(normalizedSQL), statementMetadata, nil
+	return strings.TrimSpace(strings.TrimSuffix(normalizedSQL, ";")), statementMetadata, nil
 }

--- a/obfuscate_and_normalize.go
+++ b/obfuscate_and_normalize.go
@@ -37,5 +37,5 @@ func ObfuscateAndNormalize(input string, obfuscator *Obfuscator, normalizer *Nor
 	// Dedupe collected metadata
 	dedupeStatementMetadata(statementMetadata)
 
-	return strings.TrimSpace(normalizedSQL), statementMetadata, nil
+	return trimNormalizedSQL(normalizedSQL), statementMetadata, nil
 }

--- a/obfuscate_and_normalize_test.go
+++ b/obfuscate_and_normalize_test.go
@@ -159,7 +159,7 @@ multiline comment */
 		},
 		{
 			input:    "begin execute immediate 'alter session set sql_trace=true'; end;",
-			expected: "begin execute immediate ? ; end ;",
+			expected: "begin execute immediate ? ; end",
 			statementMetadata: StatementMetadata{
 				Tables:     []string{},
 				Comments:   []string{},


### PR DESCRIPTION
Trim trailing semicolon after normalization. 
The motivation behind this change is that `pg_stat_statements` normalizes queries without semicolon, while `pg_stat_activity` retains the exact query that's executed. 
Since the semicolon (;) at the end of a SQL statement is optional and doesn't affect the "meaning" of the query, we want to left it off to simplify and standardize the pattern post normalization.