### PR TITLE
correctly tokenize file#

### DIFF
--- a/obfuscate_and_normalize_test.go
+++ b/obfuscate_and_normalize_test.go
@@ -239,6 +239,20 @@ multiline comment */
 				Size:       18,
 			},
 		},
+		{
+			input:    "SELECT file#, name, bytes, status FROM V$DATAFILE",
+			expected: "SELECT file#, name, bytes, status FROM V$DATAFILE",
+			statementMetadata: StatementMetadata{
+				Tables:     []string{"V$DATAFILE"},
+				Comments:   []string{},
+				Commands:   []string{"SELECT"},
+				Procedures: []string{},
+				Size:       16,
+			},
+			lexerOpts: []lexerOption{
+				WithDBMS(DBMSOracle),
+			},
+		},
 	}
 
 	obfuscator := NewObfuscator(

--- a/sqllexer.go
+++ b/sqllexer.go
@@ -302,7 +302,7 @@ func (s *Lexer) scanIdentifier(ch rune) Token {
 	// NOTE: this func does not distinguish between SQL keywords and identifiers
 	s.start = s.cursor
 	ch = s.nextBy(utf8.RuneLen(ch))
-	for isLetter(ch) || isDigit(ch) || ch == '.' || ch == '?' || ch == '$' {
+	for isLetter(ch) || isDigit(ch) || ch == '.' || ch == '?' || ch == '$' || ch == '#' {
 		ch = s.nextBy(utf8.RuneLen(ch))
 	}
 	// return the token as uppercase so that we can do case insensitive matching


### PR DESCRIPTION
The tokenizer incorrectly tokenize `file#` into 2 tokens `file` and `#`. This causes query like `select file#` being normalized into weird format `select file #`. 