### PR TITLE
tokenize mysql # comment

### DIFF
--- a/obfuscate_and_normalize_test.go
+++ b/obfuscate_and_normalize_test.go
@@ -253,6 +253,20 @@ multiline comment */
 				WithDBMS(DBMSOracle),
 			},
 		},
+		{
+			input:    `SELECT * FROM users WHERE id = ? # this is a comment`,
+			expected: `SELECT * FROM users WHERE id = ?`,
+			statementMetadata: StatementMetadata{
+				Tables:     []string{"users"},
+				Comments:   []string{"# this is a comment"},
+				Commands:   []string{"SELECT"},
+				Procedures: []string{},
+				Size:       30,
+			},
+			lexerOpts: []lexerOption{
+				WithDBMS(DBMSMySQL),
+			},
+		},
 	}
 
 	obfuscator := NewObfuscator(

--- a/sqllexer.go
+++ b/sqllexer.go
@@ -149,7 +149,10 @@ func (s *Lexer) Scan() Token {
 		fallthrough
 	case ch == '#':
 		if s.config.DBMS == DBMSSQLServer {
-			return s.scanIdentifier('#')
+			return s.scanIdentifier(ch)
+		} else if s.config.DBMS == DBMSMySQL {
+			// MySQL treats # as a comment
+			return s.scanSingleLineComment()
 		}
 		fallthrough
 	case isOperator(ch):

--- a/sqllexer_test.go
+++ b/sqllexer_test.go
@@ -604,6 +604,22 @@ func TestLexer(t *testing.T) {
 			},
 			lexerOpts: []lexerOption{WithDBMS(DBMSSQLServer)},
 		},
+		{
+			name:  "MySQL comment",
+			input: `SELECT * FROM users # comment`,
+			expected: []Token{
+				{IDENT, "SELECT"},
+				{WS, " "},
+				{WILDCARD, "*"},
+				{WS, " "},
+				{IDENT, "FROM"},
+				{WS, " "},
+				{IDENT, "users"},
+				{WS, " "},
+				{COMMENT, "# comment"},
+			},
+			lexerOpts: []lexerOption{WithDBMS(DBMSMySQL)},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR adds support to tokenize MySQL single line comment `# ....`