### PR TITLE
add option to keep identifier quotations

### DIFF
--- a/dbms_test.go
+++ b/dbms_test.go
@@ -100,6 +100,7 @@ func TestQueriesPerDBMS(t *testing.T) {
 								UppercaseKeywords:             false,
 								RemoveSpaceBetweenParentheses: false,
 								KeepTrailingSemicolon:         false,
+								KeepIdentifierQuotation:       false,
 							}
 						}
 
@@ -120,6 +121,7 @@ func TestQueriesPerDBMS(t *testing.T) {
 							WithUppercaseKeywords(defaultNormalizerConfig.UppercaseKeywords),
 							WithRemoveSpaceBetweenParentheses(defaultNormalizerConfig.RemoveSpaceBetweenParentheses),
 							WithKeepTrailingSemicolon(defaultNormalizerConfig.KeepTrailingSemicolon),
+							WithKeepIdentifierQuotation(defaultNormalizerConfig.KeepIdentifierQuotation),
 						)
 
 						got, statementMetadata, err := ObfuscateAndNormalize(string(tt.Input), obfuscator, normalizer, WithDBMS(dbms))

--- a/normalizer_test.go
+++ b/normalizer_test.go
@@ -184,30 +184,6 @@ multiline comment */
 			},
 		},
 		{
-			// double quoted table name
-			input:    `SELECT * FROM "users" WHERE id = ?`,
-			expected: `SELECT * FROM "users" WHERE id = ?`,
-			statementMetadata: StatementMetadata{
-				Tables:     []string{`users`},
-				Comments:   []string{},
-				Commands:   []string{"SELECT"},
-				Procedures: []string{},
-				Size:       11,
-			},
-		},
-		{
-			// double quoted table name
-			input:    `SELECT * FROM "public"."users" WHERE id = ?`,
-			expected: `SELECT * FROM "public"."users" WHERE id = ?`,
-			statementMetadata: StatementMetadata{
-				Tables:     []string{`public.users`},
-				Comments:   []string{},
-				Commands:   []string{"SELECT"},
-				Procedures: []string{},
-				Size:       18,
-			},
-		},
-		{
 			input: `
 					WITH cte AS (
 						SELECT id, name, age
@@ -609,6 +585,7 @@ func TestNormalizeDeobfuscatedSQL(t *testing.T) {
 		expected            string
 		statementMetadata   StatementMetadata
 		normalizationConfig *normalizerConfig
+		lexerOptions        []lexerOption
 	}{
 		{
 			input:    "SELECT id,name, address FROM users where id = 1",
@@ -736,6 +713,158 @@ func TestNormalizeDeobfuscatedSQL(t *testing.T) {
 				KeepSQLAlias:    true,
 			},
 		},
+		{
+			input:    `SELECT * FROM "users" WHERE id = ?`,
+			expected: `SELECT * FROM users WHERE id = ?`,
+			statementMetadata: StatementMetadata{
+				Tables:     []string{`users`},
+				Comments:   []string{},
+				Commands:   []string{"SELECT"},
+				Procedures: []string{},
+				Size:       11,
+			},
+			normalizationConfig: &normalizerConfig{
+				CollectComments: true,
+				CollectCommands: true,
+				CollectTables:   true,
+				KeepSQLAlias:    true,
+			},
+		},
+		{
+			input:    `SELECT * FROM "users" WHERE id = ?`,
+			expected: `SELECT * FROM "users" WHERE id = ?`,
+			statementMetadata: StatementMetadata{
+				Tables:     []string{`users`},
+				Comments:   []string{},
+				Commands:   []string{"SELECT"},
+				Procedures: []string{},
+				Size:       11,
+			},
+			normalizationConfig: &normalizerConfig{
+				CollectComments:         true,
+				CollectCommands:         true,
+				CollectTables:           true,
+				KeepSQLAlias:            true,
+				KeepIdentifierQuotation: true,
+			},
+		},
+		{
+			input:    `SELECT * FROM "public"."users" WHERE id = ?`,
+			expected: `SELECT * FROM public.users WHERE id = ?`,
+			statementMetadata: StatementMetadata{
+				Tables:     []string{`public.users`},
+				Comments:   []string{},
+				Commands:   []string{"SELECT"},
+				Procedures: []string{},
+				Size:       18,
+			},
+			normalizationConfig: &normalizerConfig{
+				CollectComments: true,
+				CollectCommands: true,
+				CollectTables:   true,
+				KeepSQLAlias:    true,
+			},
+		},
+		{
+			input:    `SELECT * FROM "public"."users" WHERE id = ?`,
+			expected: `SELECT * FROM "public"."users" WHERE id = ?`,
+			statementMetadata: StatementMetadata{
+				Tables:     []string{`public.users`},
+				Comments:   []string{},
+				Commands:   []string{"SELECT"},
+				Procedures: []string{},
+				Size:       18,
+			},
+			normalizationConfig: &normalizerConfig{
+				CollectComments:         true,
+				CollectCommands:         true,
+				CollectTables:           true,
+				KeepSQLAlias:            true,
+				KeepIdentifierQuotation: true,
+			},
+		},
+		{
+			input:    "SELECT * FROM `public`.`users` WHERE id = ?",
+			expected: `SELECT * FROM public.users WHERE id = ?`,
+			statementMetadata: StatementMetadata{
+				Tables:     []string{`public.users`},
+				Comments:   []string{},
+				Commands:   []string{"SELECT"},
+				Procedures: []string{},
+				Size:       18,
+			},
+			normalizationConfig: &normalizerConfig{
+				CollectComments: true,
+				CollectCommands: true,
+				CollectTables:   true,
+				KeepSQLAlias:    true,
+			},
+			lexerOptions: []lexerOption{
+				WithDBMS(DBMSMySQL),
+			},
+		},
+		{
+			input:    "SELECT * FROM `public`.`users` WHERE id = ?",
+			expected: "SELECT * FROM `public`.`users` WHERE id = ?",
+			statementMetadata: StatementMetadata{
+				Tables:     []string{`public.users`},
+				Comments:   []string{},
+				Commands:   []string{"SELECT"},
+				Procedures: []string{},
+				Size:       18,
+			},
+			normalizationConfig: &normalizerConfig{
+				CollectComments:         true,
+				CollectCommands:         true,
+				CollectTables:           true,
+				KeepSQLAlias:            true,
+				KeepIdentifierQuotation: true,
+			},
+			lexerOptions: []lexerOption{
+				WithDBMS(DBMSMySQL),
+			},
+		},
+		{
+			input:    `SELECT * FROM [public].[users] WHERE id = ?`,
+			expected: `SELECT * FROM public.users WHERE id = ?`,
+			statementMetadata: StatementMetadata{
+				Tables:     []string{`public.users`},
+				Comments:   []string{},
+				Commands:   []string{"SELECT"},
+				Procedures: []string{},
+				Size:       18,
+			},
+			normalizationConfig: &normalizerConfig{
+				CollectComments: true,
+				CollectCommands: true,
+				CollectTables:   true,
+				KeepSQLAlias:    true,
+			},
+			lexerOptions: []lexerOption{
+				WithDBMS(DBMSSQLServer),
+			},
+		},
+		{
+			input:    `SELECT * FROM [public].[users] WHERE id = ?`,
+			expected: `SELECT * FROM [public].[users] WHERE id = ?`,
+			statementMetadata: StatementMetadata{
+				Tables:     []string{`public.users`},
+				Comments:   []string{},
+				Commands:   []string{"SELECT"},
+				Procedures: []string{},
+				Size:       18,
+			},
+			normalizationConfig: &normalizerConfig{
+				CollectComments:         true,
+				CollectCommands:         true,
+				CollectTables:           true,
+				KeepSQLAlias:            true,
+				KeepIdentifierQuotation: true,
+			},
+			lexerOptions: []lexerOption{
+				WithDBMS(DBMSSQLServer),
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -745,8 +874,9 @@ func TestNormalizeDeobfuscatedSQL(t *testing.T) {
 				WithCollectCommands(test.normalizationConfig.CollectCommands),
 				WithCollectTables(test.normalizationConfig.CollectTables),
 				WithKeepSQLAlias(test.normalizationConfig.KeepSQLAlias),
+				WithKeepIdentifierQuotation(test.normalizationConfig.KeepIdentifierQuotation),
 			)
-			got, statementMetadata, err := normalizer.Normalize(test.input)
+			got, statementMetadata, err := normalizer.Normalize(test.input, test.lexerOptions...)
 			assert.NoError(t, err)
 			assert.Equal(t, test.expected, got)
 			assert.Equal(t, &test.statementMetadata, statementMetadata)

--- a/obfuscate_and_normalize_test.go
+++ b/obfuscate_and_normalize_test.go
@@ -171,7 +171,7 @@ multiline comment */
 		{
 			// double quoted table name
 			input:    `SELECT * FROM "public"."users" WHERE id = 1`,
-			expected: `SELECT * FROM "public"."users" WHERE id = ?`,
+			expected: `SELECT * FROM public.users WHERE id = ?`,
 			statementMetadata: StatementMetadata{
 				Tables:     []string{"public.users"},
 				Comments:   []string{},
@@ -183,7 +183,7 @@ multiline comment */
 		{
 			// [] quoted table name
 			input:    `SELECT * FROM [public].[users] WHERE id = 1`,
-			expected: `SELECT * FROM [public].[users] WHERE id = ?`,
+			expected: `SELECT * FROM public.users WHERE id = ?`,
 			statementMetadata: StatementMetadata{
 				Tables:     []string{"public.users"},
 				Comments:   []string{},
@@ -230,7 +230,7 @@ multiline comment */
 		},
 		{
 			input:    `select "user_id" from "public"."users"`,
-			expected: `select "user_id" from "public"."users"`,
+			expected: `select user_id from public.users`,
 			statementMetadata: StatementMetadata{
 				Tables:     []string{`public.users`},
 				Comments:   []string{},
@@ -254,7 +254,7 @@ multiline comment */
 			},
 		},
 		{
-			input:    `SELECT * FROM users WHERE id = ? # this is a comment`,
+			input:    `SELECT * FROM users WHERE id = 1 # this is a comment`,
 			expected: `SELECT * FROM users WHERE id = ?`,
 			statementMetadata: StatementMetadata{
 				Tables:     []string{"users"},
@@ -265,6 +265,20 @@ multiline comment */
 			},
 			lexerOpts: []lexerOption{
 				WithDBMS(DBMSMySQL),
+			},
+		},
+		{
+			input:    `SELECT * FROM [世界].[测试] WHERE id = 1`,
+			expected: `SELECT * FROM 世界.测试 WHERE id = ?`,
+			statementMetadata: StatementMetadata{
+				Tables:     []string{"世界.测试"},
+				Comments:   []string{},
+				Commands:   []string{"SELECT"},
+				Procedures: []string{},
+				Size:       19,
+			},
+			lexerOpts: []lexerOption{
+				WithDBMS(DBMSSQLServer),
 			},
 		},
 	}

--- a/testdata/oracle/select/quoted-identifiers-case-sensitive.json
+++ b/testdata/oracle/select/quoted-identifiers-case-sensitive.json
@@ -1,0 +1,22 @@
+{
+    "input": "SELECT \"OrderId\", \"OrderDate\", \"CustomerName\" FROM \"Sales\".\"Orders\" WHERE \"OrderStatus\" = 'Shipped';",
+    "outputs": [
+      {
+        "expected": "SELECT OrderId, OrderDate, CustomerName FROM Sales.Orders WHERE OrderStatus = ?",
+        "statement_metadata": {
+          "size": 18,
+          "tables": ["Sales.Orders"],
+          "commands": ["SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      },
+      {
+        "normalizer_config": {
+          "keep_identifier_quotation": true,
+          "Keep_trailing_semicolon": true
+        },
+        "expected": "SELECT \"OrderId\", \"OrderDate\", \"CustomerName\" FROM \"Sales\".\"Orders\" WHERE \"OrderStatus\" = ?;"
+      }
+    ]
+  }

--- a/testdata/oracle/select/quoted-identifiers-special-characters.json
+++ b/testdata/oracle/select/quoted-identifiers-special-characters.json
@@ -1,0 +1,22 @@
+{
+    "input": "SELECT * FROM \"Sales\".\"Order-Details\" WHERE \"Product#Name\" LIKE '%Gadget%';",
+    "outputs": [
+      {
+        "expected": "SELECT * FROM Sales.Order-Details WHERE Product#Name LIKE ?",
+        "statement_metadata": {
+          "size": 25,
+          "tables": ["Sales.Order-Details"],
+          "commands": ["SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      },
+      {
+        "normalizer_config": {
+          "keep_identifier_quotation": true,
+          "Keep_trailing_semicolon": true
+        },
+        "expected": "SELECT * FROM \"Sales\".\"Order-Details\" WHERE \"Product#Name\" LIKE ?;"
+      }
+    ]
+  }

--- a/testdata/postgresql/select/quoted-identifiers-case-sensitive.json
+++ b/testdata/postgresql/select/quoted-identifiers-case-sensitive.json
@@ -1,0 +1,21 @@
+{
+    "input": "SELECT \"OrderId\", \"OrderDate\", \"CustomerName\" FROM \"Sales\".\"Orders\" WHERE \"OrderStatus\" = 'Shipped'",
+    "outputs": [
+      {
+        "expected": "SELECT OrderId, OrderDate, CustomerName FROM Sales.Orders WHERE OrderStatus = ?",
+        "statement_metadata": {
+          "size": 18,
+          "tables": ["Sales.Orders"],
+          "commands": ["SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      },
+      {
+        "normalizer_config": {
+          "keep_identifier_quotation": true
+        },
+        "expected": "SELECT \"OrderId\", \"OrderDate\", \"CustomerName\" FROM \"Sales\".\"Orders\" WHERE \"OrderStatus\" = ?"
+      }
+    ]
+  }

--- a/testdata/postgresql/select/quoted-identifiers-special-characters.json
+++ b/testdata/postgresql/select/quoted-identifiers-special-characters.json
@@ -1,0 +1,21 @@
+{
+    "input": "SELECT * FROM \"Sales\".\"Order-Details\" WHERE \"Product#Name\" LIKE '%Gadget%'",
+    "outputs": [
+      {
+        "expected": "SELECT * FROM Sales.Order-Details WHERE Product#Name LIKE ?",
+        "statement_metadata": {
+          "size": 25,
+          "tables": ["Sales.Order-Details"],
+          "commands": ["SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      },
+      {
+        "normalizer_config": {
+          "keep_identifier_quotation": true
+        },
+        "expected": "SELECT * FROM \"Sales\".\"Order-Details\" WHERE \"Product#Name\" LIKE ?"
+      }
+    ]
+  }


### PR DESCRIPTION
This PR adds normalization option `KeepIdentifierQuotation`. When `KeepIdentifierQuotation` is set to `true`, identifier quotations are kept in the normalized query. 
This covers
- PostgreSQL/Oracle: Double quoted identifier
- MySQL: Backtick quoted identifier
- MSSQL: Bracket quoted identifier

```SQL
-- double quoted identifier
SELECT "ColName" FROM "TEST"."TABLE";

-- backtick quoted Identifier
SELECT `ColName` FROM `TEST`.`TABLE`;

-- bracket quoted identifier
SELECT [ColName] FROM [TEST].[TABLE];
```