### PR TITLE
[DBMON-3186] create mysql test suite

### DIFF
--- a/dbms_test.go
+++ b/dbms_test.go
@@ -37,6 +37,7 @@ func TestQueriesPerDBMS(t *testing.T) {
 		DBMSPostgres,
 		DBMSOracle,
 		DBMSSQLServer,
+		DBMSMySQL,
 	}
 
 	for _, dbms := range dbmsTypes {

--- a/sqllexer_utils.go
+++ b/sqllexer_utils.go
@@ -19,31 +19,33 @@ const (
 )
 
 var commands = map[string]bool{
-	"SELECT":   true,
-	"INSERT":   true,
-	"UPDATE":   true,
-	"DELETE":   true,
-	"CREATE":   true,
-	"ALTER":    true,
-	"DROP":     true,
-	"JOIN":     true,
-	"GRANT":    true,
-	"REVOKE":   true,
-	"COMMIT":   true,
-	"BEGIN":    true,
-	"TRUNCATE": true,
-	"MERGE":    true,
-	"EXECUTE":  true,
-	"EXEC":     true,
-	"EXPLAIN":  true,
+	"SELECT":        true,
+	"INSERT":        true,
+	"UPDATE":        true,
+	"DELETE":        true,
+	"CREATE":        true,
+	"ALTER":         true,
+	"DROP":          true,
+	"JOIN":          true,
+	"GRANT":         true,
+	"REVOKE":        true,
+	"COMMIT":        true,
+	"BEGIN":         true,
+	"TRUNCATE":      true,
+	"MERGE":         true,
+	"EXECUTE":       true,
+	"EXEC":          true,
+	"EXPLAIN":       true,
+	"STRAIGHT_JOIN": true,
 }
 
 var tableIndicators = map[string]bool{
-	"FROM":   true,
-	"JOIN":   true,
-	"INTO":   true,
-	"UPDATE": true,
-	"TABLE":  true,
+	"FROM":          true,
+	"JOIN":          true,
+	"INTO":          true,
+	"UPDATE":        true,
+	"TABLE":         true,
+	"STRAIGHT_JOIN": true, // MySQL
 }
 
 var keywords = map[string]bool{

--- a/testdata/mysql/complex/super-complex-poorly-written-sql.json
+++ b/testdata/mysql/complex/super-complex-poorly-written-sql.json
@@ -1,0 +1,16 @@
+{
+    "input": "SELECT a.*, b.totalAmount, CASE WHEN c.id IS NOT NULL THEN d.description ELSE 'N/A' END AS description\n-- Joining table a with b to get total amounts. If c.id is not null, get description from d\nFROM (SELECT id, name, status, customer_id\n      FROM orders\n      WHERE order_date > DATE_ADD(CURDATE(), INTERVAL -6 MONTH)\n      AND status IN ('Pending', 'Completed')\n      AND customer_id IN (SELECT customer_id FROM customers WHERE region IN ('East', 'West') AND last_order_date > DATE_ADD(CURDATE(), INTERVAL -1 YEAR))\n      ORDER BY name DESC) a\nINNER JOIN (SELECT order_id, SUM(amount) AS totalAmount FROM order_details GROUP BY order_id) b ON a.id = b.order_id\nLEFT JOIN audit_log c ON a.id = c.order_id\nLEFT JOIN (SELECT DISTINCT status, description FROM status_descriptions) d ON a.status = d.status\nWHERE a.name LIKE '%test%'\n-- Filtering on name containing 'test'\nAND (b.totalAmount > 1000 OR b.totalAmount IS NULL)\nORDER BY a.order_date DESC, a.name;",
+    "outputs": [
+      {
+        "expected": "SELECT a. *, b.totalAmount, CASE WHEN c.id IS NOT ? THEN d.description ELSE ? END FROM ( SELECT id, name, status, customer_id FROM orders WHERE order_date > DATE_ADD ( CURDATE ( ), INTERVAL ? MONTH ) AND status IN ( ? ) AND customer_id IN ( SELECT customer_id FROM customers WHERE region IN ( ? ) AND last_order_date > DATE_ADD ( CURDATE ( ), INTERVAL ? YEAR ) ) ORDER BY name DESC ) a INNER JOIN ( SELECT order_id, SUM ( amount ) FROM order_details GROUP BY order_id ) b ON a.id = b.order_id LEFT JOIN audit_log c ON a.id = c.order_id LEFT JOIN ( SELECT DISTINCT status, description FROM status_descriptions ) d ON a.status = d.status WHERE a.name LIKE ? AND ( b.totalAmount > ? OR b.totalAmount IS ? ) ORDER BY a.order_date DESC, a.name",
+        "statement_metadata": {
+          "size": 195,
+          "tables": ["orders", "customers", "order_details", "audit_log", "status_descriptions"],
+          "commands": ["SELECT", "JOIN"],
+          "comments": ["-- Joining table a with b to get total amounts. If c.id is not null, get description from d", "-- Filtering on name containing 'test'"],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/complex/super-complex-sql-multiple-joins.json
+++ b/testdata/mysql/complex/super-complex-sql-multiple-joins.json
@@ -1,0 +1,16 @@
+{
+    "input": "SELECT a.id, a.name, IFNULL(b.totalAmount, 0) AS totalAmount, c.comment, d.productCount, e.latestOrderDate\n-- Extremely complex query combining multiple joins, subqueries, and inline views\nFROM (SELECT id, name FROM customers WHERE status = 'Active') a\nJOIN (SELECT customer_id, SUM(amount) AS totalAmount FROM orders GROUP BY customer_id) b ON a.id = b.customer_id\nLEFT JOIN (SELECT customer_id, comment FROM customer_feedback WHERE rating = 5 ORDER BY feedback_date DESC LIMIT 1) c ON a.id = c.customer_id\nLEFT JOIN (SELECT customer_id, COUNT(*) AS productCount FROM order_details GROUP BY customer_id) d ON a.id = d.customer_id\nLEFT JOIN (SELECT customer_id, MAX(order_date) AS latestOrderDate FROM orders WHERE status IN ('Completed', 'Shipped') GROUP BY customer_id) e ON a.id = e.customer_id\nWHERE a.name LIKE '%Corp%' AND (b.totalAmount > 1000 OR d.productCount > 5)\nORDER BY a.name, totalAmount DESC;",
+    "outputs": [
+      {
+        "expected": "SELECT a.id, a.name, IFNULL ( b.totalAmount, ? ), c.comment, d.productCount, e.latestOrderDate FROM ( SELECT id, name FROM customers WHERE status = ? ) a JOIN ( SELECT customer_id, SUM ( amount ) FROM orders GROUP BY customer_id ) b ON a.id = b.customer_id LEFT JOIN ( SELECT customer_id, comment FROM customer_feedback WHERE rating = ? ORDER BY feedback_date DESC LIMIT ? ) c ON a.id = c.customer_id LEFT JOIN ( SELECT customer_id, COUNT ( * ) FROM order_details GROUP BY customer_id ) d ON a.id = d.customer_id LEFT JOIN ( SELECT customer_id, MAX ( order_date ) FROM orders WHERE status IN ( ? ) GROUP BY customer_id ) e ON a.id = e.customer_id WHERE a.name LIKE ? AND ( b.totalAmount > ? OR d.productCount > ? ) ORDER BY a.name, totalAmount DESC",
+        "statement_metadata": {
+          "size": 136,
+          "tables": ["customers", "orders", "customer_feedback", "order_details"],
+          "commands": ["SELECT", "JOIN"],
+          "comments": ["-- Extremely complex query combining multiple joins, subqueries, and inline views"],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/complex/super-complex-sql-nested-subqueries.json
+++ b/testdata/mysql/complex/super-complex-sql-nested-subqueries.json
@@ -1,0 +1,15 @@
+{
+  "input": "SELECT t1.id, t1.status, t3.totalAmount, t4.commentsCount, CASE WHEN t5.latestCommentDate IS NOT NULL THEN t5.latestCommentDate ELSE 'No Comments' END AS latestComment\n-- Complex query joining multiple subqueries and using conditional logic\nFROM (SELECT id, status FROM orders WHERE customer_id IN (SELECT id FROM customers WHERE region = 'North') AND order_date > (SELECT MAX(order_date) FROM orders WHERE status = 'Pending')) t1\nJOIN (SELECT order_id, SUM(amount) AS totalAmount FROM order_details WHERE product_id IN (SELECT id FROM products WHERE name LIKE '%Premium%') GROUP BY order_id) t3 ON t1.id = t3.order_id\nLEFT JOIN (SELECT order_id, COUNT(*) AS commentsCount FROM order_comments GROUP BY order_id) t4 ON t1.id = t4.order_id\nLEFT JOIN (SELECT order_id, MAX(comment_date) AS latestCommentDate FROM order_comments WHERE comment LIKE '%urgent%' GROUP BY order_id) t5 ON t1.id = t5.order_id\nWHERE t1.status NOT IN ('Cancelled', 'Returned') AND (t3.totalAmount > 500 OR t4.commentsCount > 10)\nORDER BY t1.id, latestComment DESC;",
+  "outputs": [
+    {
+      "expected": "SELECT t?.id, t?.status, t?.totalAmount, t?.commentsCount, CASE WHEN t?.latestCommentDate IS NOT ? THEN t?.latestCommentDate ELSE ? END FROM ( SELECT id, status FROM orders WHERE customer_id IN ( SELECT id FROM customers WHERE region = ? ) AND order_date > ( SELECT MAX ( order_date ) FROM orders WHERE status = ? ) ) t? JOIN ( SELECT order_id, SUM ( amount ) FROM order_details WHERE product_id IN ( SELECT id FROM products WHERE name LIKE ? ) GROUP BY order_id ) t? ON t?.id = t?.order_id LEFT JOIN ( SELECT order_id, COUNT ( * ) FROM order_comments GROUP BY order_id ) t? ON t?.id = t?.order_id LEFT JOIN ( SELECT order_id, MAX ( comment_date ) FROM order_comments WHERE comment LIKE ? GROUP BY order_id ) t? ON t?.id = t?.order_id WHERE t?.status NOT IN ( ? ) AND ( t?.totalAmount > ? OR t?.commentsCount > ? ) ORDER BY t?.id, latestComment DESC",
+      "statement_metadata": {
+        "size": 132,
+        "tables": ["orders", "customers", "order_details", "products", "order_comments"],
+        "commands": ["SELECT", "JOIN"],
+        "comments": ["-- Complex query joining multiple subqueries and using conditional logic"],
+        "procedures": []
+      }
+    }
+  ]
+}

--- a/testdata/mysql/delete/delete-basic.json
+++ b/testdata/mysql/delete/delete-basic.json
@@ -1,0 +1,16 @@
+{
+    "input": "DELETE FROM orders WHERE status = 'Cancelled';",
+    "outputs": [
+      {
+        "expected": "DELETE FROM orders WHERE status = ?",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["DELETE"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/delete/delete-cascade.json
+++ b/testdata/mysql/delete/delete-cascade.json
@@ -1,0 +1,16 @@
+{
+    "input": "DELETE FROM customers WHERE region = 'North'; -- Assuming CASCADE DELETE is set up on the foreign key in the orders table",
+    "outputs": [
+      {
+        "expected": "DELETE FROM customers WHERE region = ?",
+        "statement_metadata": {
+          "size": 90,
+          "tables": ["customers"],
+          "commands": ["DELETE"],
+          "comments": ["-- Assuming CASCADE DELETE is set up on the foreign key in the orders table"],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/delete/delete-cascading-triggers.json
+++ b/testdata/mysql/delete/delete-cascading-triggers.json
@@ -1,0 +1,16 @@
+{
+    "input": "DELETE FROM customers WHERE id = 1; -- Assumes a trigger exists for cascading delete to orders",
+    "outputs": [
+      {
+        "expected": "DELETE FROM customers WHERE id = ?",
+        "statement_metadata": {
+          "size": 73,
+          "tables": ["customers"],
+          "commands": ["DELETE"],
+          "comments": ["-- Assumes a trigger exists for cascading delete to orders"],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/delete/delete-conditional-logic.json
+++ b/testdata/mysql/delete/delete-conditional-logic.json
@@ -1,0 +1,16 @@
+{
+    "input": "DELETE FROM orders WHERE status = IF(DAYOFWEEK(CURDATE()) = 1, 'Pending', 'Completed');",
+    "outputs": [
+      {
+        "expected": "DELETE FROM orders WHERE status = IF ( DAYOFWEEK ( CURDATE ( ) ) = ?, ?, ? )",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["DELETE"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/delete/delete-foreign-key-constraints.json
+++ b/testdata/mysql/delete/delete-foreign-key-constraints.json
@@ -1,0 +1,16 @@
+{
+    "input": "DELETE FROM orders WHERE id IN (SELECT order_id FROM order_details WHERE quantity = 0);",
+    "outputs": [
+      {
+        "expected": "DELETE FROM orders WHERE id IN ( SELECT order_id FROM order_details WHERE quantity = ? )",
+        "statement_metadata": {
+          "size": 31,
+          "tables": ["orders", "order_details"],
+          "commands": ["DELETE", "SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/delete/delete-free-disk-space.json
+++ b/testdata/mysql/delete/delete-free-disk-space.json
@@ -1,0 +1,16 @@
+{
+    "input": "DELETE FROM orders WHERE order_date < '2020-01-01'; OPTIMIZE TABLE orders;",
+    "outputs": [
+      {
+        "expected": "DELETE FROM orders WHERE order_date < ?; OPTIMIZE TABLE orders",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["DELETE"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/delete/delete-join-multiple-conditions.json
+++ b/testdata/mysql/delete/delete-join-multiple-conditions.json
@@ -1,0 +1,16 @@
+{
+    "input": "DELETE o FROM orders o JOIN customers c ON o.customer_id = c.id WHERE o.status = 'Completed' AND c.region = 'South';",
+    "outputs": [
+      {
+        "expected": "DELETE o FROM orders o JOIN customers c ON o.customer_id = c.id WHERE o.status = ? AND c.region = ?",
+        "statement_metadata": {
+          "size": 25,
+          "tables": ["orders", "customers"],
+          "commands": ["DELETE", "JOIN"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/delete/delete-lock-tables.json
+++ b/testdata/mysql/delete/delete-lock-tables.json
@@ -1,0 +1,16 @@
+{
+    "input": "LOCK TABLES orders WRITE; DELETE FROM orders WHERE status = 'Failed'; UNLOCK TABLES;",
+    "outputs": [
+      {
+        "expected": "LOCK TABLES orders WRITE; DELETE FROM orders WHERE status = ?; UNLOCK TABLES",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["DELETE"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/delete/delete-multiple-tables.json
+++ b/testdata/mysql/delete/delete-multiple-tables.json
@@ -1,0 +1,16 @@
+{
+    "input": "DELETE orders, order_details FROM orders INNER JOIN order_details ON orders.id = order_details.order_id WHERE orders.status = 'Obsolete';",
+    "outputs": [
+      {
+        "expected": "DELETE orders, order_details FROM orders INNER JOIN order_details ON orders.id = order_details.order_id WHERE orders.status = ?",
+        "statement_metadata": {
+          "size": 29,
+          "tables": ["orders", "order_details"],
+          "commands": ["DELETE", "JOIN"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/delete/delete-optimized-conditions.json
+++ b/testdata/mysql/delete/delete-optimized-conditions.json
@@ -1,0 +1,16 @@
+{
+    "input": "DELETE FROM orders WHERE status = 'Completed' AND order_date < DATE_SUB(NOW(), INTERVAL 1 YEAR);",
+    "outputs": [
+      {
+        "expected": "DELETE FROM orders WHERE status = ? AND order_date < DATE_SUB ( NOW ( ), INTERVAL ? YEAR )",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["DELETE"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/delete/delete-order-by-limit.json
+++ b/testdata/mysql/delete/delete-order-by-limit.json
@@ -1,0 +1,16 @@
+{
+    "input": "DELETE FROM orders WHERE status = 'Completed' ORDER BY order_date DESC LIMIT 5;",
+    "outputs": [
+      {
+        "expected": "DELETE FROM orders WHERE status = ? ORDER BY order_date DESC LIMIT ?",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["DELETE"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/delete/delete-range-conditions.json
+++ b/testdata/mysql/delete/delete-range-conditions.json
@@ -1,0 +1,16 @@
+{
+    "input": "DELETE FROM orders WHERE amount BETWEEN 100 AND 500;",
+    "outputs": [
+      {
+        "expected": "DELETE FROM orders WHERE amount BETWEEN ? AND ?",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["DELETE"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/delete/delete-regular-expressions.json
+++ b/testdata/mysql/delete/delete-regular-expressions.json
@@ -1,0 +1,16 @@
+{
+    "input": "DELETE FROM orders WHERE status REGEXP '^C.*';",
+    "outputs": [
+      {
+        "expected": "DELETE FROM orders WHERE status REGEXP ?",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["DELETE"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/delete/delete-safe-update-mode.json
+++ b/testdata/mysql/delete/delete-safe-update-mode.json
@@ -1,0 +1,16 @@
+{
+    "input": "SET SQL_SAFE_UPDATES = 0; DELETE FROM orders WHERE customer_id = 1; SET SQL_SAFE_UPDATES = 1;",
+    "outputs": [
+      {
+        "expected": "SET SQL_SAFE_UPDATES = ?; DELETE FROM orders WHERE customer_id = ?; SET SQL_SAFE_UPDATES = ?",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["DELETE"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/delete/delete-subquery-optimization.json
+++ b/testdata/mysql/delete/delete-subquery-optimization.json
@@ -1,0 +1,16 @@
+{
+    "input": "DELETE FROM orders WHERE id IN (SELECT id FROM orders WHERE status = 'Failed' LIMIT 10);",
+    "outputs": [
+      {
+        "expected": "DELETE FROM orders WHERE id IN ( SELECT id FROM orders WHERE status = ? LIMIT ? )",
+        "statement_metadata": {
+          "size": 18,
+          "tables": ["orders"],
+          "commands": ["DELETE", "SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/delete/delete-truncate.json
+++ b/testdata/mysql/delete/delete-truncate.json
@@ -1,0 +1,16 @@
+{
+    "input": "TRUNCATE TABLE order_details;",
+    "outputs": [
+      {
+        "expected": "TRUNCATE TABLE order_details",
+        "statement_metadata": {
+          "size": 21,
+          "tables": ["order_details"],
+          "commands": ["TRUNCATE"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/delete/delete-using-subquery.json
+++ b/testdata/mysql/delete/delete-using-subquery.json
@@ -1,0 +1,16 @@
+{
+    "input": "DELETE FROM orders WHERE customer_id IN (SELECT id FROM customers WHERE region = 'West');",
+    "outputs": [
+      {
+        "expected": "DELETE FROM orders WHERE customer_id IN ( SELECT id FROM customers WHERE region = ? )",
+        "statement_metadata": {
+          "size": 27,
+          "tables": ["orders", "customers"],
+          "commands": ["DELETE", "SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/delete/delete-with-join.json
+++ b/testdata/mysql/delete/delete-with-join.json
@@ -1,0 +1,16 @@
+{
+    "input": "DELETE o FROM orders o JOIN customers c ON o.customer_id = c.id WHERE c.region = 'East' AND o.status = 'Pending';",
+    "outputs": [
+      {
+        "expected": "DELETE o FROM orders o JOIN customers c ON o.customer_id = c.id WHERE c.region = ? AND o.status = ?",
+        "statement_metadata": {
+          "size": 25,
+          "tables": ["orders", "customers"],
+          "commands": ["DELETE", "JOIN"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/delete/delete-with-limit.json
+++ b/testdata/mysql/delete/delete-with-limit.json
@@ -1,0 +1,16 @@
+{
+    "input": "DELETE FROM orders WHERE status = 'Pending' LIMIT 10;",
+    "outputs": [
+      {
+        "expected": "DELETE FROM orders WHERE status = ? LIMIT ?",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["DELETE"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/delete/delete-with-user-variables.json
+++ b/testdata/mysql/delete/delete-with-user-variables.json
@@ -1,0 +1,16 @@
+{
+    "input": "SET @max_id = (SELECT MAX(id) FROM orders); DELETE FROM orders WHERE id = @max_id;",
+    "outputs": [
+      {
+        "expected": "SET @max_id = ( SELECT MAX ( id ) FROM orders ); DELETE FROM orders WHERE id = @max_id",
+        "statement_metadata": {
+          "size": 18,
+          "tables": ["orders"],
+          "commands": ["SELECT", "DELETE"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/insert/batch-insert-multiple-rows.json
+++ b/testdata/mysql/insert/batch-insert-multiple-rows.json
@@ -1,0 +1,16 @@
+{
+    "input": "INSERT INTO orders (customer_id, status) VALUES (1, 'Pending'), (2, 'Completed'), (3, 'Processing');",
+    "outputs": [
+      {
+        "expected": "INSERT INTO orders ( customer_id, status ) VALUES ( ? ), ( ? ), ( ? )",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["INSERT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/insert/insert-auto-increment.json
+++ b/testdata/mysql/insert/insert-auto-increment.json
@@ -1,0 +1,16 @@
+{
+    "input": "INSERT INTO orders (customer_id, status) VALUES (3, 'Processing');",
+    "outputs": [
+      {
+        "expected": "INSERT INTO orders ( customer_id, status ) VALUES ( ? )",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["INSERT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/insert/insert-basic.json
+++ b/testdata/mysql/insert/insert-basic.json
@@ -1,0 +1,16 @@
+{
+    "input": "INSERT INTO orders (customer_id, order_date, status) VALUES (1, NOW(), 'Pending');",
+    "outputs": [
+      {
+        "expected": "INSERT INTO orders ( customer_id, order_date, status ) VALUES ( ?, NOW ( ), ? )",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["INSERT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/insert/insert-blob-data.json
+++ b/testdata/mysql/insert/insert-blob-data.json
@@ -1,0 +1,16 @@
+{
+    "input": "INSERT INTO orders (customer_id, status, document) VALUES (5, 'Pending', LOAD_FILE('/path/to/file'));",
+    "outputs": [
+      {
+        "expected": "INSERT INTO orders ( customer_id, status, document ) VALUES ( ?, LOAD_FILE ( ? ) )",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["INSERT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/insert/insert-enum-data.json
+++ b/testdata/mysql/insert/insert-enum-data.json
@@ -1,0 +1,16 @@
+{
+    "input": "INSERT INTO orders (customer_id, status, order_type) VALUES (7, 'Pending', 'Express');",
+    "outputs": [
+      {
+        "expected": "INSERT INTO orders ( customer_id, status, order_type ) VALUES ( ? )",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["INSERT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/insert/insert-ignore.json
+++ b/testdata/mysql/insert/insert-ignore.json
@@ -1,0 +1,16 @@
+{
+    "input": "INSERT IGNORE INTO orders (id, customer_id, status) VALUES (1, 10, 'Cancelled');",
+    "outputs": [
+      {
+        "expected": "INSERT IGNORE INTO orders ( id, customer_id, status ) VALUES ( ? )",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["INSERT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/insert/insert-json-data.json
+++ b/testdata/mysql/insert/insert-json-data.json
@@ -1,0 +1,16 @@
+{
+    "input": "INSERT INTO orders (customer_id, status, details) VALUES (1, 'Pending', '{\"items\": [\"item1\", \"item2\"]}');",
+    "outputs": [
+      {
+        "expected": "INSERT INTO orders ( customer_id, status, details ) VALUES ( ? )",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["INSERT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/insert/insert-on-duplicate-key.json
+++ b/testdata/mysql/insert/insert-on-duplicate-key.json
@@ -1,0 +1,16 @@
+{
+    "input": "INSERT INTO orders (id, customer_id, status) VALUES (100, 2, 'Pending') ON DUPLICATE KEY UPDATE status = 'Pending';",
+    "outputs": [
+      {
+        "expected": "INSERT INTO orders ( id, customer_id, status ) VALUES ( ? ) ON DUPLICATE KEY UPDATE status = ?",
+        "statement_metadata": {
+          "size": 24,
+          "tables": ["orders", "status"],
+          "commands": ["INSERT", "UPDATE"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/insert/insert-select-union.json
+++ b/testdata/mysql/insert/insert-select-union.json
@@ -1,0 +1,16 @@
+{
+    "input": "INSERT INTO orders (customer_id, status) SELECT customer_id, status FROM archived_orders UNION ALL SELECT customer_id, status FROM special_orders;",
+    "outputs": [
+      {
+        "expected": "INSERT INTO orders ( customer_id, status ) SELECT customer_id, status FROM archived_orders UNION ALL SELECT customer_id, status FROM special_orders",
+        "statement_metadata": {
+          "size": 47,
+          "tables": ["orders", "archived_orders", "special_orders"],
+          "commands": ["INSERT", "SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/insert/insert-spatial-data.json
+++ b/testdata/mysql/insert/insert-spatial-data.json
@@ -1,0 +1,16 @@
+{
+    "input": "INSERT INTO orders (customer_id, status, location) VALUES (6, 'Delivered', ST_GeomFromText('POINT(1 1)'));",
+    "outputs": [
+      {
+        "expected": "INSERT INTO orders ( customer_id, status, location ) VALUES ( ?, ST_GeomFromText ( ? ) )",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["INSERT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/insert/insert-using-last-insert-id.json
+++ b/testdata/mysql/insert/insert-using-last-insert-id.json
@@ -1,0 +1,16 @@
+{
+    "input": "INSERT INTO customers (name) VALUES ('John Doe'); INSERT INTO orders (customer_id, status) VALUES (LAST_INSERT_ID(), 'Pending');",
+    "outputs": [
+      {
+        "expected": "INSERT INTO customers ( name ) VALUES ( ? ); INSERT INTO orders ( customer_id, status ) VALUES ( LAST_INSERT_ID ( ), ? )",
+        "statement_metadata": {
+          "size": 21,
+          "tables": ["customers", "orders"],
+          "commands": ["INSERT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/insert/insert-using-subquery.json
+++ b/testdata/mysql/insert/insert-using-subquery.json
@@ -1,0 +1,16 @@
+{
+    "input": "INSERT INTO order_audit (order_id, status) SELECT id, status FROM orders WHERE customer_id = 1;",
+    "outputs": [
+      {
+        "expected": "INSERT INTO order_audit ( order_id, status ) SELECT id, status FROM orders WHERE customer_id = ?",
+        "statement_metadata": {
+          "size": 29,
+          "tables": ["order_audit", "orders"],
+          "commands": ["INSERT", "SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/insert/insert-with-conditional-logic.json
+++ b/testdata/mysql/insert/insert-with-conditional-logic.json
@@ -1,0 +1,16 @@
+{
+    "input": "INSERT INTO orders (customer_id, status, amount) SELECT id, 'New', IF(region = 'West', 100, 50) FROM customers;",
+    "outputs": [
+      {
+        "expected": "INSERT INTO orders ( customer_id, status, amount ) SELECT id, ?, IF ( region = ?, ?, ? ) FROM customers",
+        "statement_metadata": {
+          "size": 27,
+          "tables": ["orders", "customers"],
+          "commands": ["INSERT", "SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/insert/insert-with-curdate-curtime.json
+++ b/testdata/mysql/insert/insert-with-curdate-curtime.json
@@ -1,0 +1,16 @@
+{
+    "input": "INSERT INTO orders (customer_id, status, order_date, order_time) VALUES (15, 'Pending', CURDATE(), CURTIME());",
+    "outputs": [
+      {
+        "expected": "INSERT INTO orders ( customer_id, status, order_date, order_time ) VALUES ( ?, CURDATE ( ), CURTIME ( ) )",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["INSERT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/insert/insert-with-encryption-functions.json
+++ b/testdata/mysql/insert/insert-with-encryption-functions.json
@@ -1,0 +1,16 @@
+{
+    "input": "INSERT INTO orders (customer_id, status, encrypted_note) VALUES (13, 'Pending', AES_ENCRYPT('Confidential note', 'encryption_key'));",
+    "outputs": [
+      {
+        "expected": "INSERT INTO orders ( customer_id, status, encrypted_note ) VALUES ( ?, AES_ENCRYPT ( ? ) )",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["INSERT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/insert/insert-with-generated-columns.json
+++ b/testdata/mysql/insert/insert-with-generated-columns.json
@@ -1,0 +1,15 @@
+{
+    "input": "INSERT INTO orders (customer_id, status, total_incl_tax) VALUES (12, 'Pending', 150); -- total_incl_tax is a generated column",
+    "outputs": [
+      {
+        "expected": "INSERT INTO orders ( customer_id, status, total_incl_tax ) VALUES ( ? )",
+        "statement_metadata": {
+          "size": 51,
+          "tables": ["orders"],
+          "commands": ["INSERT"],
+          "comments": ["-- total_incl_tax is a generated column"],
+          "procedures": []
+        }
+      }
+    ]
+  }

--- a/testdata/mysql/insert/insert-with-replace.json
+++ b/testdata/mysql/insert/insert-with-replace.json
@@ -1,0 +1,16 @@
+{
+    "input": "REPLACE INTO orders (id, customer_id, status) VALUES (1, 9, 'Completed');",
+    "outputs": [
+      {
+        "expected": "REPLACE INTO orders ( id, customer_id, status ) VALUES ( ? )",
+        "statement_metadata": {
+          "size": 6,
+          "tables": ["orders"],
+          "commands": [],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/insert/insert-with-set-syntax.json
+++ b/testdata/mysql/insert/insert-with-set-syntax.json
@@ -1,0 +1,16 @@
+{
+    "input": "INSERT INTO orders SET customer_id = 8, status = 'Processing', order_date = CURDATE();",
+    "outputs": [
+      {
+        "expected": "INSERT INTO orders SET customer_id = ?, status = ?, order_date = CURDATE ( )",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["INSERT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/insert/insert-with-spatial-data.json
+++ b/testdata/mysql/insert/insert-with-spatial-data.json
@@ -1,0 +1,16 @@
+{
+    "input": "INSERT INTO orders (customer_id, status, location) VALUES (14, 'Pending', ST_GeomFromText('POINT(1 1)'));",
+    "outputs": [
+      {
+        "expected": "INSERT INTO orders ( customer_id, status, location ) VALUES ( ?, ST_GeomFromText ( ? ) )",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["INSERT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/insert/insert-with-timestamp.json
+++ b/testdata/mysql/insert/insert-with-timestamp.json
@@ -1,0 +1,16 @@
+{
+    "input": "INSERT INTO orders (customer_id, status, created_at) VALUES (4, 'Shipped', CURRENT_TIMESTAMP);",
+    "outputs": [
+      {
+        "expected": "INSERT INTO orders ( customer_id, status, created_at ) VALUES ( ?, CURRENT_TIMESTAMP )",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["INSERT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/procedure/complex-procedure-error-handling.json
+++ b/testdata/mysql/procedure/complex-procedure-error-handling.json
@@ -1,0 +1,16 @@
+{
+    "input": "CREATE PROCEDURE UpdateOrderStatus(IN orderId INT, IN newStatus VARCHAR(20)) BEGIN\n DECLARE EXIT HANDLER FOR SQLEXCEPTION\n BEGIN\n -- Handle error\n ROLLBACK;\n END;\n START TRANSACTION;\n UPDATE orders SET status = newStatus WHERE id = orderId;\n IF ROW_COUNT() = 0 THEN\n SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'No rows updated';\n END IF;\n COMMIT;\n END;",
+    "outputs": [
+      {
+        "expected": "CREATE PROCEDURE UpdateOrderStatus ( IN orderId INT, IN newStatus VARCHAR ( ? ) ) BEGIN DECLARE EXIT HANDLER FOR SQLEXCEPTION BEGIN ROLLBACK; END; START TRANSACTION; UPDATE orders SET status = newStatus WHERE id = orderId; IF ROW_COUNT ( ) = ? THEN SIGNAL SQLSTATE ? SET MESSAGE_TEXT = ?; END IF; COMMIT; END",
+        "statement_metadata": {
+          "size": 61,
+          "tables": ["orders"],
+          "commands": ["CREATE", "BEGIN", "UPDATE", "COMMIT"],
+          "comments": ["-- Handle error"],
+          "procedures": ["UpdateOrderStatus"]
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/procedure/stored-procedure-basic.json
+++ b/testdata/mysql/procedure/stored-procedure-basic.json
@@ -1,0 +1,15 @@
+{
+    "input": "CREATE PROCEDURE GetAllOrders() BEGIN SELECT * FROM orders; END;",
+    "outputs": [
+      {
+        "expected": "CREATE PROCEDURE GetAllOrders ( ) BEGIN SELECT * FROM orders; END",
+        "statement_metadata": {
+          "size": 35,
+          "tables": ["orders"],
+          "commands": ["CREATE", "BEGIN", "SELECT"],
+          "comments": [],
+          "procedures": ["GetAllOrders"]
+        }
+      }
+    ]
+  }

--- a/testdata/mysql/procedure/stored-procedure-conditional-logic-loop.json
+++ b/testdata/mysql/procedure/stored-procedure-conditional-logic-loop.json
@@ -1,0 +1,15 @@
+{
+    "input": "CREATE PROCEDURE ProcessOrders() BEGIN\n DECLARE done INT DEFAULT 0;\n DECLARE a INT;\n DECLARE cur1 CURSOR FOR SELECT id FROM orders WHERE status = 'Pending';\n DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = 1;\n OPEN cur1;\n read_loop: LOOP\n FETCH cur1 INTO a;\n IF done THEN\n LEAVE read_loop;\n END IF;\n UPDATE orders SET status = 'Processing' WHERE id = a;\n END LOOP;\n CLOSE cur1;\n END;",
+    "outputs": [
+      {
+        "expected": "CREATE PROCEDURE ProcessOrders ( ) BEGIN DECLARE done INT DEFAULT ?; DECLARE a INT; DECLARE cur? CURSOR FOR SELECT id FROM orders WHERE status = ?; DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = ?; OPEN cur?; read_loop : LOOP FETCH cur? INTO a; IF done THEN LEAVE read_loop; END IF; UPDATE orders SET status = ? WHERE id = a; END LOOP; CLOSE cur?; END",
+        "statement_metadata": {
+          "size": 43,
+          "tables": ["orders", "a"],
+          "commands": ["CREATE", "BEGIN", "SELECT", "UPDATE"],
+          "comments": [],
+          "procedures": ["ProcessOrders"]
+        }
+      }
+    ]
+  }

--- a/testdata/mysql/procedure/stored-procedure-cursor.json
+++ b/testdata/mysql/procedure/stored-procedure-cursor.json
@@ -1,0 +1,16 @@
+{
+    "input": "CREATE PROCEDURE FetchOrders() BEGIN DECLARE done INT DEFAULT FALSE; DECLARE cur CURSOR FOR SELECT id FROM orders; DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE; OPEN cur; read_loop: LOOP FETCH cur INTO order_id; IF done THEN LEAVE read_loop; END IF; /* process each order */ END LOOP; CLOSE cur; END;",
+    "outputs": [
+      {
+        "expected": "CREATE PROCEDURE FetchOrders ( ) BEGIN DECLARE done INT DEFAULT ?; DECLARE cur CURSOR FOR SELECT id FROM orders; DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = ?; OPEN cur; read_loop : LOOP FETCH cur INTO order_id; IF done THEN LEAVE read_loop; END IF; END LOOP; CLOSE cur; END",
+        "statement_metadata": {
+          "size": 66,
+          "tables": ["orders", "order_id"],
+          "commands": ["CREATE", "BEGIN", "SELECT"],
+          "comments": ["/* process each order */"],
+          "procedures": ["FetchOrders"]
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/procedure/stored-procedure-dynamic-sql.json
+++ b/testdata/mysql/procedure/stored-procedure-dynamic-sql.json
@@ -1,0 +1,16 @@
+{
+    "input": "CREATE PROCEDURE DynamicQuery(IN tbl_name VARCHAR(50)) BEGIN SET @s = CONCAT('SELECT * FROM ', tbl_name); PREPARE stmt FROM @s; EXECUTE stmt; DEALLOCATE PREPARE stmt; END;",
+    "outputs": [
+      {
+        "expected": "CREATE PROCEDURE DynamicQuery ( IN tbl_name VARCHAR ( ? ) ) BEGIN SET @s = CONCAT ( ?, tbl_name ); PREPARE stmt FROM @s; EXECUTE stmt; DEALLOCATE PREPARE stmt; END",
+        "statement_metadata": {
+          "size": 30,
+          "tables": [],
+          "commands": ["CREATE", "BEGIN", "EXECUTE"],
+          "comments": [],
+          "procedures": ["DynamicQuery"]
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/procedure/stored-procedure-error-handling.json
+++ b/testdata/mysql/procedure/stored-procedure-error-handling.json
@@ -1,0 +1,16 @@
+{
+    "input": "CREATE PROCEDURE SafeUpdate(IN order_id INT, IN new_status VARCHAR(50)) BEGIN DECLARE EXIT HANDLER FOR SQLEXCEPTION BEGIN -- handle error\n SET @error = 'An error occurred'; END; UPDATE orders SET status = new_status WHERE id = order_id; END;",
+    "outputs": [
+      {
+        "expected": "CREATE PROCEDURE SafeUpdate ( IN order_id INT, IN new_status VARCHAR ( ? ) ) BEGIN DECLARE EXIT HANDLER FOR SQLEXCEPTION BEGIN SET @error = ?; END; UPDATE orders SET status = new_status WHERE id = order_id; END",
+        "statement_metadata": {
+          "size": 48,
+          "tables": ["orders"],
+          "commands": ["CREATE", "BEGIN", "UPDATE"],
+          "comments": ["-- handle error"],
+          "procedures": ["SafeUpdate"]
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/procedure/stored-procedure-input-output-parameters.json
+++ b/testdata/mysql/procedure/stored-procedure-input-output-parameters.json
@@ -1,0 +1,16 @@
+{
+    "input": "CREATE PROCEDURE GetTotalOrders(OUT total INT) BEGIN SELECT COUNT(*) INTO total FROM orders; END;",
+    "outputs": [
+      {
+        "expected": "CREATE PROCEDURE GetTotalOrders ( OUT total INT ) BEGIN SELECT COUNT ( * ) INTO total FROM orders; END",
+        "statement_metadata": {
+          "size": 42,
+          "tables": ["total", "orders"],
+          "commands": ["CREATE", "BEGIN", "SELECT"],
+          "comments": [],
+          "procedures": ["GetTotalOrders"]
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/procedure/stored-procedure-loop-control.json
+++ b/testdata/mysql/procedure/stored-procedure-loop-control.json
@@ -1,0 +1,15 @@
+{
+  "input": "CREATE PROCEDURE ProcessOrders() BEGIN DECLARE done INT DEFAULT FALSE; DECLARE cur CURSOR FOR SELECT id FROM orders; DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE; OPEN cur; read_loop: LOOP FETCH cur INTO order_id; IF done THEN LEAVE read_loop; END IF; UPDATE orders SET status = 'Processed' WHERE id = order_id; END LOOP; CLOSE cur; END;",
+  "outputs": [
+    {
+      "expected": "CREATE PROCEDURE ProcessOrders ( ) BEGIN DECLARE done INT DEFAULT ?; DECLARE cur CURSOR FOR SELECT id FROM orders; DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = ?; OPEN cur; read_loop : LOOP FETCH cur INTO order_id; IF done THEN LEAVE read_loop; END IF; UPDATE orders SET status = ? WHERE id = order_id; END LOOP; CLOSE cur; END",
+      "statement_metadata": {
+        "size": 50,
+        "tables": ["orders", "order_id"],
+        "commands": ["CREATE", "BEGIN", "SELECT", "UPDATE"],
+        "comments": [],
+        "procedures": ["ProcessOrders"]
+      }
+    }
+  ]
+}

--- a/testdata/mysql/procedure/stored-procedure-parameters.json
+++ b/testdata/mysql/procedure/stored-procedure-parameters.json
@@ -1,0 +1,15 @@
+{
+    "input": "CREATE PROCEDURE GetOrdersByStatus(IN status VARCHAR(20)) BEGIN SELECT * FROM orders WHERE orders.status = status; END;",
+    "outputs": [
+      {
+        "expected": "CREATE PROCEDURE GetOrdersByStatus ( IN status VARCHAR ( ? ) ) BEGIN SELECT * FROM orders WHERE orders.status = status; END",
+        "statement_metadata": {
+          "size": 40,
+          "tables": ["orders"],
+          "commands": ["CREATE", "BEGIN", "SELECT"],
+          "comments": [],
+          "procedures": ["GetOrdersByStatus"]
+        }
+      }
+    ]
+  }

--- a/testdata/mysql/procedure/stored-procedure-transaction-management.json
+++ b/testdata/mysql/procedure/stored-procedure-transaction-management.json
@@ -1,0 +1,15 @@
+{
+    "input": "CREATE PROCEDURE UpdateOrderTransaction(IN order_id INT, IN new_status VARCHAR(50)) BEGIN DECLARE EXIT HANDLER FOR SQLEXCEPTION BEGIN ROLLBACK; END; START TRANSACTION; UPDATE orders SET status = new_status WHERE id = order_id; COMMIT; END;",
+    "outputs": [
+      {
+        "expected": "CREATE PROCEDURE UpdateOrderTransaction ( IN order_id INT, IN new_status VARCHAR ( ? ) ) BEGIN DECLARE EXIT HANDLER FOR SQLEXCEPTION BEGIN ROLLBACK; END; START TRANSACTION; UPDATE orders SET status = new_status WHERE id = order_id; COMMIT; END",
+        "statement_metadata": {
+          "size": 51,
+          "tables": ["orders"],
+          "commands": ["CREATE", "BEGIN", "UPDATE", "COMMIT"],
+          "comments": [],
+          "procedures": ["UpdateOrderTransaction"]
+        }
+      }
+    ]
+  }

--- a/testdata/mysql/select/bit-data-type.json
+++ b/testdata/mysql/select/bit-data-type.json
@@ -1,0 +1,16 @@
+{
+    "input": "SELECT id, status, (is_paid & 1) AS isPaidFlag FROM orders;",
+    "outputs": [
+      {
+        "expected": "SELECT id, status, ( is_paid & ? ) FROM orders",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/select/blob-text-data-types.json
+++ b/testdata/mysql/select/blob-text-data-types.json
@@ -1,0 +1,16 @@
+{
+    "input": "SELECT id, SUBSTRING(order_notes, 1, 100) AS short_notes FROM orders WHERE LENGTH(document_blob) > 1024;",
+    "outputs": [
+      {
+        "expected": "SELECT id, SUBSTRING ( order_notes, ?, ? ) FROM orders WHERE LENGTH ( document_blob ) > ?",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/select/decimal-data-type.json
+++ b/testdata/mysql/select/decimal-data-type.json
@@ -1,0 +1,16 @@
+{
+    "input": "SELECT id, ROUND(total_amount, 2) AS rounded_total FROM orders;",
+    "outputs": [
+      {
+        "expected": "SELECT id, ROUND ( total_amount, ? ) FROM orders",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/select/enum-set-data-types.json
+++ b/testdata/mysql/select/enum-set-data-types.json
@@ -1,0 +1,16 @@
+{
+    "input": "SELECT id, order_type, status_flags FROM order_details WHERE order_type = 'Standard' AND FIND_IN_SET('urgent', status_flags);",
+    "outputs": [
+      {
+        "expected": "SELECT id, order_type, status_flags FROM order_details WHERE order_type = ? AND FIND_IN_SET ( ?, status_flags )",
+        "statement_metadata": {
+          "size": 19,
+          "tables": ["order_details"],
+          "commands": ["SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/select/full-text-search-innodb.json
+++ b/testdata/mysql/select/full-text-search-innodb.json
@@ -1,0 +1,16 @@
+{
+    "input": "CREATE FULLTEXT INDEX ft_index ON orders (description); SELECT * FROM orders WHERE MATCH(description) AGAINST ('+delivery -return' IN BOOLEAN MODE);",
+    "outputs": [
+      {
+        "expected": "CREATE FULLTEXT INDEX ft_index ON orders ( description ); SELECT * FROM orders WHERE MATCH ( description ) AGAINST ( ? IN BOOLEAN MODE )",
+        "statement_metadata": {
+          "size": 18,
+          "tables": ["orders"],
+          "commands": ["CREATE", "SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/select/select-aggregate-functions.json
+++ b/testdata/mysql/select/select-aggregate-functions.json
@@ -1,0 +1,16 @@
+{
+    "input": "SELECT customer_id, COUNT(*) AS total_orders FROM orders GROUP BY customer_id HAVING COUNT(*) > 5;",
+    "outputs": [
+      {
+        "expected": "SELECT customer_id, COUNT ( * ) FROM orders GROUP BY customer_id HAVING COUNT ( * ) > ?",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/select/select-basic.json
+++ b/testdata/mysql/select/select-basic.json
@@ -1,0 +1,16 @@
+{
+    "input": "SELECT id, customer_id, order_date, status FROM orders WHERE status = 'Pending';",
+    "outputs": [
+      {
+        "expected": "SELECT id, customer_id, order_date, status FROM orders WHERE status = ?",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/select/select-case-statement.json
+++ b/testdata/mysql/select/select-case-statement.json
@@ -1,0 +1,16 @@
+{
+    "input": "SELECT id, CASE WHEN status = 'Pending' THEN 'P' WHEN status = 'Completed' THEN 'C' ELSE 'Other' END AS status_code FROM orders;",
+    "outputs": [
+      {
+        "expected": "SELECT id, CASE WHEN status = ? THEN ? WHEN status = ? THEN ? ELSE ? END FROM orders",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/select/select-coalesce-function.json
+++ b/testdata/mysql/select/select-coalesce-function.json
@@ -1,0 +1,16 @@
+{
+    "input": "SELECT id, COALESCE(comments, 'No comments') AS order_comments FROM orders;",
+    "outputs": [
+      {
+        "expected": "SELECT id, COALESCE ( comments, ? ) FROM orders",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/select/select-conditional-case.json
+++ b/testdata/mysql/select/select-conditional-case.json
@@ -1,0 +1,16 @@
+{
+    "input": "SELECT id, CASE WHEN status = 'Pending' THEN 'P' WHEN status = 'Completed' THEN 'C' ELSE 'Other' END AS status_code FROM orders;",
+    "outputs": [
+      {
+        "expected": "SELECT id, CASE WHEN status = ? THEN ? WHEN status = ? THEN ? ELSE ? END FROM orders",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/select/select-date-functions.json
+++ b/testdata/mysql/select/select-date-functions.json
@@ -1,0 +1,16 @@
+{
+    "input": "SELECT id, YEAR(order_date) AS order_year FROM orders WHERE MONTH(order_date) = 1;",
+    "outputs": [
+      {
+        "expected": "SELECT id, YEAR ( order_date ) FROM orders WHERE MONTH ( order_date ) = ?",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/select/select-distinct.json
+++ b/testdata/mysql/select/select-distinct.json
@@ -1,0 +1,16 @@
+{
+    "input": "SELECT DISTINCT status FROM orders;",
+    "outputs": [
+      {
+        "expected": "SELECT DISTINCT status FROM orders",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/select/select-full-text-search.json
+++ b/testdata/mysql/select/select-full-text-search.json
@@ -1,0 +1,16 @@
+{
+    "input": "SELECT id, MATCH (description) AGAINST ('+shipping -delayed' IN BOOLEAN MODE) AS score FROM orders WHERE MATCH (description) AGAINST ('+shipping -delayed' IN BOOLEAN MODE) > 0;",
+    "outputs": [
+      {
+        "expected": "SELECT id, MATCH ( description ) AGAINST ( ? IN BOOLEAN MODE ) FROM orders WHERE MATCH ( description ) AGAINST ( ? IN BOOLEAN MODE ) > ?",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/select/select-geospatial-data.json
+++ b/testdata/mysql/select/select-geospatial-data.json
@@ -1,0 +1,16 @@
+{
+    "input": "SELECT id, ST_AsText(location) AS location FROM orders WHERE ST_Distance_Sphere(location, ST_GeomFromText('POINT(10 20)')) < 10000;",
+    "outputs": [
+      {
+        "expected": "SELECT id, ST_AsText ( location ) FROM orders WHERE ST_Distance_Sphere ( location, ST_GeomFromText ( ? ) ) < ?",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/select/select-group-concat.json
+++ b/testdata/mysql/select/select-group-concat.json
@@ -1,0 +1,16 @@
+{
+    "input": "SELECT customer_id, GROUP_CONCAT(status ORDER BY order_date DESC SEPARATOR ', ') AS order_statuses FROM orders GROUP BY customer_id;",
+    "outputs": [
+      {
+        "expected": "SELECT customer_id, GROUP_CONCAT ( status ORDER BY order_date DESC SEPARATOR ? ) FROM orders GROUP BY customer_id",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/select/select-join-aliases.json
+++ b/testdata/mysql/select/select-join-aliases.json
@@ -1,0 +1,16 @@
+{
+    "input": "SELECT o.id, c.name AS customer_name, o.status FROM orders o LEFT JOIN customers c ON o.customer_id = c.id;",
+    "outputs": [
+      {
+        "expected": "SELECT o.id, c.name, o.status FROM orders o LEFT JOIN customers c ON o.customer_id = c.id",
+        "statement_metadata": {
+          "size": 25,
+          "tables": ["orders", "customers"],
+          "commands": ["SELECT", "JOIN"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/select/select-join.json
+++ b/testdata/mysql/select/select-join.json
@@ -1,0 +1,16 @@
+{
+    "input": "SELECT o.id, c.name, o.status FROM orders o JOIN customers c ON o.customer_id = c.id WHERE o.status = 'Completed';",
+    "outputs": [
+      {
+        "expected": "SELECT o.id, c.name, o.status FROM orders o JOIN customers c ON o.customer_id = c.id WHERE o.status = ?",
+        "statement_metadata": {
+          "size": 25,
+          "tables": ["orders", "customers"],
+          "commands": ["SELECT", "JOIN"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/select/select-json-functions.json
+++ b/testdata/mysql/select/select-json-functions.json
@@ -1,0 +1,16 @@
+{
+    "input": "SELECT id, JSON_EXTRACT(order_details, '$.items[0].name') AS first_item_name FROM orders WHERE JSON_CONTAINS(order_details, '\"Active\"', '$.status');",
+    "outputs": [
+      {
+        "expected": "SELECT id, JSON_EXTRACT ( order_details, ? ) FROM orders WHERE JSON_CONTAINS ( order_details, ?, ? )",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/select/select-limit-offset.json
+++ b/testdata/mysql/select/select-limit-offset.json
@@ -1,0 +1,16 @@
+{
+    "input": "SELECT * FROM orders ORDER BY order_date DESC LIMIT 10 OFFSET 5;",
+    "outputs": [
+      {
+        "expected": "SELECT * FROM orders ORDER BY order_date DESC LIMIT ? OFFSET ?",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/select/select-lock-in-share-mode.json
+++ b/testdata/mysql/select/select-lock-in-share-mode.json
@@ -1,0 +1,16 @@
+{
+    "input": "SELECT * FROM orders WHERE status = 'Pending' LOCK IN SHARE MODE;",
+    "outputs": [
+      {
+        "expected": "SELECT * FROM orders WHERE status = ? LOCK IN SHARE MODE",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/select/select-natural-join.json
+++ b/testdata/mysql/select/select-natural-join.json
@@ -1,0 +1,16 @@
+{
+    "input": "SELECT * FROM orders NATURAL JOIN customers;",
+    "outputs": [
+      {
+        "expected": "SELECT * FROM orders NATURAL JOIN customers",
+        "statement_metadata": {
+          "size": 25,
+          "tables": ["orders", "customers"],
+          "commands": ["SELECT", "JOIN"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/select/select-parameter-binding.json
+++ b/testdata/mysql/select/select-parameter-binding.json
@@ -1,0 +1,16 @@
+{
+    "input": "SELECT id, status FROM orders WHERE customer_id = ?;",
+    "outputs": [
+      {
+        "expected": "SELECT id, status FROM orders WHERE customer_id = ?",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/select/select-regex.json
+++ b/testdata/mysql/select/select-regex.json
@@ -1,0 +1,16 @@
+{
+    "input": "SELECT id, customer_id FROM orders WHERE status REGEXP '^Comp.*';",
+    "outputs": [
+      {
+        "expected": "SELECT id, customer_id FROM orders WHERE status REGEXP ?",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/select/select-straight-join.json
+++ b/testdata/mysql/select/select-straight-join.json
@@ -1,0 +1,16 @@
+{
+    "input": "SELECT * FROM orders STRAIGHT_JOIN customers ON orders.customer_id = customers.id;",
+    "outputs": [
+      {
+        "expected": "SELECT * FROM orders STRAIGHT_JOIN customers ON orders.customer_id = customers.id",
+        "statement_metadata": {
+          "size": 34,
+          "tables": ["orders", "customers"],
+          "commands": ["SELECT", "STRAIGHT_JOIN"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/select/select-string-functions.json
+++ b/testdata/mysql/select/select-string-functions.json
@@ -1,0 +1,16 @@
+{
+    "input": "SELECT id, UPPER(status) AS status_upper FROM orders;",
+    "outputs": [
+      {
+        "expected": "SELECT id, UPPER ( status ) FROM orders",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/select/select-subquery.json
+++ b/testdata/mysql/select/select-subquery.json
@@ -1,0 +1,16 @@
+{
+    "input": "SELECT id, (SELECT name FROM customers WHERE id = orders.customer_id) AS customer_name FROM orders;",
+    "outputs": [
+      {
+        "expected": "SELECT id, ( SELECT name FROM customers WHERE id = orders.customer_id ) FROM orders",
+        "statement_metadata": {
+          "size": 21,
+          "tables": ["customers", "orders"],
+          "commands": ["SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/select/select-user-defined-variables.json
+++ b/testdata/mysql/select/select-user-defined-variables.json
@@ -1,0 +1,16 @@
+{
+    "input": "SET @orderRank := 0; SELECT @orderRank := @orderRank + 1 AS rank, id, status FROM orders ORDER BY id;",
+    "outputs": [
+      {
+        "expected": "SET @orderRank := ?; SELECT @orderRank := @orderRank + ?, id, status FROM orders ORDER BY id",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/select/select-variable-assignment.json
+++ b/testdata/mysql/select/select-variable-assignment.json
@@ -1,0 +1,16 @@
+{
+    "input": "SELECT @orderCount := COUNT(*) FROM orders WHERE status = 'Completed';",
+    "outputs": [
+      {
+        "expected": "SELECT @orderCount := COUNT ( * ) FROM orders WHERE status = ?",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/select/select-window-functions.json
+++ b/testdata/mysql/select/select-window-functions.json
@@ -1,0 +1,16 @@
+{
+    "input": "SELECT id, status, RANK() OVER (PARTITION BY customer_id ORDER BY order_date DESC) AS rank FROM orders;",
+    "outputs": [
+      {
+        "expected": "SELECT id, status, RANK ( ) OVER ( PARTITION BY customer_id ORDER BY order_date DESC ) FROM orders",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/select/spatial-data-types-functions.json
+++ b/testdata/mysql/select/spatial-data-types-functions.json
@@ -1,0 +1,16 @@
+{
+    "input": "SELECT id, ST_AsText(location) AS location FROM orders WHERE ST_Distance_Sphere(location, ST_GeomFromText('POINT(10 20)')) < 10000;",
+    "outputs": [
+      {
+        "expected": "SELECT id, ST_AsText ( location ) FROM orders WHERE ST_Distance_Sphere ( location, ST_GeomFromText ( ? ) ) < ?",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/select/spatial-geometry-data-types.json
+++ b/testdata/mysql/select/spatial-geometry-data-types.json
@@ -1,0 +1,16 @@
+{
+    "input": "SELECT id, ST_AsText(location) FROM orders WHERE ST_Distance(location, ST_GeomFromText('POINT(1 1)')) < 100;",
+    "outputs": [
+      {
+        "expected": "SELECT id, ST_AsText ( location ) FROM orders WHERE ST_Distance ( location, ST_GeomFromText ( ? ) ) < ?",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/select/system-versioned-tables.json
+++ b/testdata/mysql/select/system-versioned-tables.json
@@ -1,0 +1,16 @@
+{
+    "input": "CREATE TABLE orders_with_history (id INT, status VARCHAR(20)) WITH SYSTEM VERSIONING;",
+    "outputs": [
+      {
+        "expected": "CREATE TABLE orders_with_history ( id INT, status VARCHAR ( ? ) ) WITH SYSTEM VERSIONING",
+        "statement_metadata": {
+          "size": 25,
+          "tables": ["orders_with_history"],
+          "commands": ["CREATE"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/select/using-temporary-tables.json
+++ b/testdata/mysql/select/using-temporary-tables.json
@@ -1,0 +1,16 @@
+{
+    "input": "CREATE TEMPORARY TABLE temp_orders SELECT * FROM orders; SELECT * FROM temp_orders WHERE status = 'Pending'; DROP TEMPORARY TABLE temp_orders;",
+    "outputs": [
+      {
+        "expected": "CREATE TEMPORARY TABLE temp_orders SELECT * FROM orders; SELECT * FROM temp_orders WHERE status = ?; DROP TEMPORARY TABLE temp_orders",
+        "statement_metadata": {
+          "size": 33,
+          "tables": ["temp_orders", "orders"],
+          "commands": ["CREATE", "SELECT", "DROP"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/select/virtual-generated-columns.json
+++ b/testdata/mysql/select/virtual-generated-columns.json
@@ -1,0 +1,16 @@
+{
+    "input": "CREATE TABLE orders_with_virtual (id INT, amount DECIMAL(10, 2), total_incl_tax DECIMAL(10, 2) GENERATED ALWAYS AS (amount * 1.1) STORED);",
+    "outputs": [
+      {
+        "expected": "CREATE TABLE orders_with_virtual ( id INT, amount DECIMAL ( ? ), total_incl_tax DECIMAL ( ? ) GENERATED ALWAYS AS ( amount * ? ) STORED )",
+        "statement_metadata": {
+          "size": 25,
+          "tables": ["orders_with_virtual"],
+          "commands": ["CREATE"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/update/bulk-update-multiple-conditions.json
+++ b/testdata/mysql/update/bulk-update-multiple-conditions.json
@@ -1,0 +1,16 @@
+{
+    "input": "UPDATE orders SET status = IF(amount > 1000, 'High Value', 'Regular'), order_date = IF(status = 'Pending', CURDATE(), order_date);",
+    "outputs": [
+      {
+        "expected": "UPDATE orders SET status = IF ( amount > ?, ?, ? ), order_date = IF ( status = ?, CURDATE ( ), order_date )",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["UPDATE"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/update/conditional-update-case.json
+++ b/testdata/mysql/update/conditional-update-case.json
@@ -1,0 +1,16 @@
+{
+    "input": "UPDATE orders SET status = CASE WHEN amount > 100 THEN 'High Value' ELSE 'Regular' END;",
+    "outputs": [
+      {
+        "expected": "UPDATE orders SET status = CASE WHEN amount > ? THEN ? ELSE ? END",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["UPDATE"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/update/update-basic.json
+++ b/testdata/mysql/update/update-basic.json
@@ -1,0 +1,15 @@
+{
+    "input": "UPDATE orders SET status = 'Completed' WHERE status = 'Pending';",
+    "outputs": [
+      {
+        "expected": "UPDATE orders SET status = ? WHERE status = ?",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["UPDATE"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }

--- a/testdata/mysql/update/update-case-aggregate-functions.json
+++ b/testdata/mysql/update/update-case-aggregate-functions.json
@@ -1,0 +1,16 @@
+{
+    "input": "UPDATE orders o SET o.status = CASE WHEN avg_amount > 500 THEN 'High' ELSE 'Low' END FROM (SELECT customer_id, AVG(amount) as avg_amount FROM orders GROUP BY customer_id) a WHERE o.customer_id = a.customer_id;",
+    "outputs": [
+      {
+        "expected": "UPDATE orders o SET o.status = CASE WHEN avg_amount > ? THEN ? ELSE ? END FROM ( SELECT customer_id, AVG ( amount ) FROM orders GROUP BY customer_id ) a WHERE o.customer_id = a.customer_id",
+        "statement_metadata": {
+          "size": 18,
+          "tables": ["orders"],
+          "commands": ["UPDATE", "SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/update/update-date-time-functions.json
+++ b/testdata/mysql/update/update-date-time-functions.json
@@ -1,0 +1,16 @@
+{
+    "input": "UPDATE orders SET order_date = CURDATE(), order_time = CURTIME() WHERE status = 'Pending';",
+    "outputs": [
+      {
+        "expected": "UPDATE orders SET order_date = CURDATE ( ), order_time = CURTIME ( ) WHERE status = ?",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["UPDATE"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/update/update-encryption-functions.json
+++ b/testdata/mysql/update/update-encryption-functions.json
@@ -1,0 +1,16 @@
+{
+    "input": "UPDATE orders SET encrypted_note = AES_ENCRYPT('Confidential', 'key') WHERE id = 1;",
+    "outputs": [
+      {
+        "expected": "UPDATE orders SET encrypted_note = AES_ENCRYPT ( ? ) WHERE id = ?",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["UPDATE"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/update/update-enum-data.json
+++ b/testdata/mysql/update/update-enum-data.json
@@ -1,0 +1,16 @@
+{
+    "input": "UPDATE orders SET order_type = 'Standard' WHERE order_type = 'Express';",
+    "outputs": [
+      {
+        "expected": "UPDATE orders SET order_type = ? WHERE order_type = ?",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["UPDATE"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/update/update-json-functions.json
+++ b/testdata/mysql/update/update-json-functions.json
@@ -1,0 +1,16 @@
+{
+    "input": "UPDATE orders SET details = JSON_SET(details, '$.shippingMethod', 'Express') WHERE id = 1;",
+    "outputs": [
+      {
+        "expected": "UPDATE orders SET details = JSON_SET ( details, ?, ? ) WHERE id = ?",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["UPDATE"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/update/update-json-modify.json
+++ b/testdata/mysql/update/update-json-modify.json
@@ -1,0 +1,16 @@
+{
+    "input": "UPDATE orders SET details = JSON_SET(details, '$.status', 'Updated') WHERE JSON_EXTRACT(details, '$.priority') = 'High';",
+    "outputs": [
+      {
+        "expected": "UPDATE orders SET details = JSON_SET ( details, ?, ? ) WHERE JSON_EXTRACT ( details, ? ) = ?",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["UPDATE"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/update/update-lock-tables.json
+++ b/testdata/mysql/update/update-lock-tables.json
@@ -1,0 +1,16 @@
+{
+    "input": "LOCK TABLES orders WRITE; UPDATE orders SET status = 'Cancelled' WHERE status = 'Pending'; UNLOCK TABLES;",
+    "outputs": [
+      {
+        "expected": "LOCK TABLES orders WRITE; UPDATE orders SET status = ? WHERE status = ?; UNLOCK TABLES",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["UPDATE"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/update/update-math-functions.json
+++ b/testdata/mysql/update/update-math-functions.json
@@ -1,0 +1,16 @@
+{
+    "input": "UPDATE orders SET amount = amount * 1.1 WHERE status = 'Completed';",
+    "outputs": [
+      {
+        "expected": "UPDATE orders SET amount = amount * ? WHERE status = ?",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["UPDATE"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/update/update-optimizing-conditions.json
+++ b/testdata/mysql/update/update-optimizing-conditions.json
@@ -1,0 +1,16 @@
+{
+    "input": "UPDATE orders SET status = 'Archived' WHERE status = 'Completed' AND order_date < DATE_SUB(NOW(), INTERVAL 1 YEAR);",
+    "outputs": [
+      {
+        "expected": "UPDATE orders SET status = ? WHERE status = ? AND order_date < DATE_SUB ( NOW ( ), INTERVAL ? YEAR )",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["UPDATE"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/update/update-order-by-limit.json
+++ b/testdata/mysql/update/update-order-by-limit.json
@@ -1,0 +1,16 @@
+{
+    "input": "UPDATE orders SET status = 'Cancelled' WHERE status = 'Pending' ORDER BY order_date ASC LIMIT 10;",
+    "outputs": [
+      {
+        "expected": "UPDATE orders SET status = ? WHERE status = ? ORDER BY order_date ASC LIMIT ?",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["UPDATE"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/update/update-regular-expressions.json
+++ b/testdata/mysql/update/update-regular-expressions.json
@@ -1,0 +1,16 @@
+{
+    "input": "UPDATE orders SET status = 'Query' WHERE status REGEXP '^Q.*';",
+    "outputs": [
+      {
+        "expected": "UPDATE orders SET status = ? WHERE status REGEXP ?",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["UPDATE"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/update/update-spatial-data.json
+++ b/testdata/mysql/update/update-spatial-data.json
@@ -1,0 +1,16 @@
+{
+    "input": "UPDATE orders SET location = ST_GeomFromText('POINT(1 1)') WHERE id = 1;",
+    "outputs": [
+      {
+        "expected": "UPDATE orders SET location = ST_GeomFromText ( ? ) WHERE id = ?",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["UPDATE"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/update/update-string-functions.json
+++ b/testdata/mysql/update/update-string-functions.json
@@ -1,0 +1,16 @@
+{
+    "input": "UPDATE orders SET status = CONCAT(status, ' - Updated') WHERE id = 1;",
+    "outputs": [
+      {
+        "expected": "UPDATE orders SET status = CONCAT ( status, ? ) WHERE id = ?",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["UPDATE"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/update/update-user-defined-variables.json
+++ b/testdata/mysql/update/update-user-defined-variables.json
@@ -1,0 +1,16 @@
+{
+    "input": "SET @new_status = 'Delayed'; UPDATE orders SET status = @new_status WHERE status = 'Pending';",
+    "outputs": [
+      {
+        "expected": "SET @new_status = ?; UPDATE orders SET status = @new_status WHERE status = ?",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["UPDATE"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/update/update-using-variables.json
+++ b/testdata/mysql/update/update-using-variables.json
@@ -1,0 +1,16 @@
+{
+    "input": "SET @new_status = 'Shipped'; UPDATE orders SET status = @new_status WHERE status = 'Processing';",
+    "outputs": [
+      {
+        "expected": "SET @new_status = ?; UPDATE orders SET status = @new_status WHERE status = ?",
+        "statement_metadata": {
+          "size": 12,
+          "tables": ["orders"],
+          "commands": ["UPDATE"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/update/update-with-join.json
+++ b/testdata/mysql/update/update-with-join.json
@@ -1,0 +1,16 @@
+{
+    "input": "UPDATE orders o JOIN customers c ON o.customer_id = c.id SET o.status = 'Processing' WHERE c.region = 'East';",
+    "outputs": [
+      {
+        "expected": "UPDATE orders o JOIN customers c ON o.customer_id = c.id SET o.status = ? WHERE c.region = ?",
+        "statement_metadata": {
+          "size": 25,
+          "tables": ["orders", "customers"],
+          "commands": ["UPDATE", "JOIN"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  

--- a/testdata/mysql/update/update-with-subquery.json
+++ b/testdata/mysql/update/update-with-subquery.json
@@ -1,0 +1,16 @@
+{
+    "input": "UPDATE orders SET status = 'Archived' WHERE id IN (SELECT id FROM orders WHERE order_date < '2020-01-01');",
+    "outputs": [
+      {
+        "expected": "UPDATE orders SET status = ? WHERE id IN ( SELECT id FROM orders WHERE order_date < ? )",
+        "statement_metadata": {
+          "size": 18,
+          "tables": ["orders"],
+          "commands": ["UPDATE", "SELECT"],
+          "comments": [],
+          "procedures": []
+        }
+      }
+    ]
+  }
+  


### PR DESCRIPTION
This PR creates test suite for `mysql`. Similar as the Postgres https://github.com/DataDog/go-sqllexer/pull/25, the goal is to have a comprehensive list of `mysql` specific SQL statements that we can leverage to verify the completeness and correctness of the package.
Some tests also covers features that specifically exist in `MariaDB` or `InnoDB`, for example

- Full-Text Search in InnoDB and MyISAM
- Spatial Data Types and Functions (GIS)
- JSON Data Type and Functions
- Window Functions
- Virtual/Generated Columns
- System-Versioned Tables (MariaDB)