### PR TITLE
[postgres] fix table name for select only statement

### DIFF
--- a/normalizer_test.go
+++ b/normalizer_test.go
@@ -368,6 +368,17 @@ multiline comment */
 				Size:       9,
 			},
 		},
+		{
+			input:    "SELECT * FROM ONLY users WHERE id = ?",
+			expected: "SELECT * FROM ONLY users WHERE id = ?",
+			statementMetadata: StatementMetadata{
+				Tables:     []string{"users"},
+				Comments:   []string{},
+				Commands:   []string{"SELECT"},
+				Procedures: []string{},
+				Size:       11,
+			},
+		},
 	}
 
 	normalizer := NewNormalizer(

--- a/sqllexer_test.go
+++ b/sqllexer_test.go
@@ -647,6 +647,29 @@ func TestLexer(t *testing.T) {
 				{IDENT, "users"},
 			},
 		},
+		{
+			name:  "select only",
+			input: "SELECT * FROM ONLY tab1 where id = 1",
+			expected: []Token{
+				{IDENT, "SELECT"},
+				{WS, " "},
+				{WILDCARD, "*"},
+				{WS, " "},
+				{IDENT, "FROM"},
+				{WS, " "},
+				{IDENT, "ONLY"},
+				{WS, " "},
+				{IDENT, "tab1"},
+				{WS, " "},
+				{IDENT, "where"},
+				{WS, " "},
+				{IDENT, "id"},
+				{WS, " "},
+				{OPERATOR, "="},
+				{WS, " "},
+				{NUMBER, "1"},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/sqllexer_utils.go
+++ b/sqllexer_utils.go
@@ -52,6 +52,7 @@ var tableIndicators = map[string]bool{
 	"EXISTS":        true, // Drop Table If Exists
 	"STRAIGHT_JOIN": true, // MySQL
 	"CLONE":         true, // Snowflake
+	"ONLY":          true, // PostgreSQL
 }
 
 var keywords = map[string]bool{
@@ -147,6 +148,7 @@ var keywords = map[string]bool{
 	"OF":         true,
 	"SKIP":       true,
 	"IF":         true,
+	"ONLY":       true,
 }
 
 func isWhitespace(ch rune) bool {

--- a/testdata/postgresql/select/select-only.json
+++ b/testdata/postgresql/select/select-only.json
@@ -1,0 +1,20 @@
+{
+  "input": "SELECT * FROM ONLY users, ONLY orders WHERE users.id = orders.user_id;",
+  "outputs": [
+    {
+      "expected": "SELECT * FROM ONLY users, ONLY orders WHERE users.id = orders.user_id",
+      "statement_metadata": {
+        "size": 17,
+        "tables": [
+          "users",
+          "orders"
+        ],
+        "commands": [
+          "SELECT"
+        ],
+        "comments": [],
+        "procedures": []
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR fixes a bug where Postgresql keyword `ONLY` is wrongly categorized as a table name. 