### PR TITLE
improve allocations resulting from replacer build in `trimQuotes`

### DIFF
--- a/sqllexer_utils.go
+++ b/sqllexer_utils.go
@@ -281,7 +281,30 @@ func replaceDigits(input string, placeholder string) string {
 	return builder.String()
 }
 
+var (
+	doubleQuotesReplacer  = strings.NewReplacer("\"", "")
+	backQuotesReplacer    = strings.NewReplacer("`", "")
+	bracketQuotesReplacer = strings.NewReplacer("[", "", "]", "")
+)
+
 func trimQuotes(input string, delim string, closingDelim string) string {
-	replacer := strings.NewReplacer(delim, "", closingDelim, "")
+	var replacer *strings.Replacer
+	switch {
+	// common quote types get an already allocated replacer
+	case delim == closingDelim && delim == "\"":
+		replacer = doubleQuotesReplacer
+	case delim == closingDelim && delim == "`":
+		replacer = backQuotesReplacer
+	case delim == "[" && closingDelim == "]":
+		replacer = bracketQuotesReplacer
+
+	// common case of `delim` and `closingDelim` being the same, gets a simpler replacer
+	case delim == closingDelim:
+		replacer = strings.NewReplacer(delim, "")
+
+	default:
+		replacer = strings.NewReplacer(delim, "", closingDelim, "")
+	}
+
 	return replacer.Replace(input)
 }


### PR DESCRIPTION
The `trimQuotes` function is used to trim the quotes when going from a raw token (for example `"table"."column"`) to a normalized identifier/table name (here `table.column`). This function allocates a new `strings.Replacer` every time which can be quite costly ([example profile](https://ddstaging.datadoghq.com/profiling/explorer?query=service%3Asystem-probe%20kube_cluster_name%3Astripe%20&agg_m=count&agg_m_source=base&agg_t=count&cols=timestamp%2Cservice%2C%40metrics.core_cpu_cores%2C%40metrics.core_alloc_bytes_per_sec%2Cversion%2Chost%2C%40metrics.go_lifetime_heap_bytes&event=AgAAAZJnMzc8VeeAVwAAAAAAAAAYAAAAAEFaSm5NemhJQUFBOFVpNHFjZVVia0FBQQAAACQAAAAAMDE5MjY3M2EtOGFmYy00ZDU3LThmY2YtNjEyOGZlNzc4YWEx&my_code=disabled&profile_type=alloc-size&profileId=AZJnMzhIAAA8Ui4qceUbkAAA&refresh_mode=paused&stream_sort=%40metrics.core_alloc_bytes_per_sec%2Cdesc&viz=stream&from_ts=1728307022122&to_ts=1728310622122&live=false) of this function allocating ~7GiB of memory in a 5min window).

To improve this situation this PR improves the common case by pre-allocating the replacers for the common quote types (the one I was able to find in the lexer code), falling back to a newly allocated replacer otherwise.