### PR TITLE
fix sqlserver named parameter tokenization

### DIFF
--- a/obfuscate_and_normalize_test.go
+++ b/obfuscate_and_normalize_test.go
@@ -412,14 +412,14 @@ multiline comment */
 			},
 		},
 		{
-			input:    `DELETE [discount]  WHERE [description]=@1`,
-			expected: `DELETE discount WHERE description = @1`,
+			input:    `DELETE FROM [discount]  WHERE [description]=@1`,
+			expected: `DELETE FROM discount WHERE description = @1`,
 			statementMetadata: StatementMetadata{
 				Tables:     []string{"discount"},
 				Comments:   []string{},
 				Commands:   []string{"DELETE"},
 				Procedures: []string{},
-				Size:       11,
+				Size:       14,
 			},
 			lexerOpts: []lexerOption{
 				WithDBMS(DBMSSQLServer),

--- a/obfuscate_and_normalize_test.go
+++ b/obfuscate_and_normalize_test.go
@@ -411,6 +411,20 @@ multiline comment */
 				Size:       11,
 			},
 		},
+		{
+			input:    `DELETE [discount]  WHERE [description]=@1`,
+			expected: `DELETE discount WHERE description = @1`,
+			statementMetadata: StatementMetadata{
+				Tables:     []string{"discount"},
+				Comments:   []string{},
+				Commands:   []string{"DELETE"},
+				Procedures: []string{},
+				Size:       11,
+			},
+			lexerOpts: []lexerOption{
+				WithDBMS(DBMSSQLServer),
+			},
+		},
 	}
 
 	obfuscator := NewObfuscator(

--- a/sqllexer.go
+++ b/sqllexer.go
@@ -370,7 +370,7 @@ func (s *Lexer) scanWhitespace() Token {
 func (s *Lexer) scanOperator(lastCh rune) Token {
 	s.start = s.cursor
 	ch := s.next()
-	for isOperator(ch) && !(lastCh == '=' && ch == '?') {
+	for isOperator(ch) && !(lastCh == '=' && (ch == '?' || ch == '@')) {
 		// hack: we don't want to treat "=?" as an single operator
 		lastCh = ch
 		ch = s.next()


### PR DESCRIPTION
The PR fixes sqlserver named parameter tokenization where `=@1` query like `where id=@1` are incorrectly tokenized as an operator `=@` and causing `1` become a literal. 