### PR TITLE
implement allocation free fast path for `isBoolean` and `isNull`

### DIFF
--- a/sqllexer_utils.go
+++ b/sqllexer_utils.go
@@ -247,10 +247,20 @@ func isProcedure(token *Token) bool {
 }
 
 func isBoolean(ident string) bool {
+	// allocation free fast path for common cases
+	if ident == "true" || ident == "false" || ident == "TRUE" || ident == "FALSE" {
+		return true
+	}
+
 	return strings.ToUpper(ident) == "TRUE" || strings.ToUpper(ident) == "FALSE"
 }
 
 func isNull(ident string) bool {
+	// allocation free fast path for common cases
+	if ident == "null" || ident == "NULL" {
+		return true
+	}
+
 	return strings.ToUpper(ident) == "NULL"
 }
 


### PR DESCRIPTION
[Example profile](https://ddstaging.datadoghq.com/profiling/explorer?query=service%3Adatadog-agent%20kube_cluster_name%3Astripe&agg_m=count&agg_m_source=base&agg_t=count&cols=timestamp%2Cservice%2C%40metrics.core_cpu_cores%2C%40metrics.core_alloc_bytes_per_sec%2Cversion%2Chost%2C%40metrics.go_lifetime_heap_bytes&event=AwAAAZMQBN8e7UpmUwAAABhBWk1RQk45MUFBRG1WRzFmdmh1N193QUEAAAAkMDE5MzEwMGItMzgxOC00MWU3LThjMTctZGQ1ZGUyYWMyN2UwAAVfaw&my_code=disabled&profile_type=alloc-size&profileId=AZMQBN91AADmVG1fvhu7_wAA&refresh_mode=paused&stream_sort=%40metrics.core_cpu_cores%2Cdesc&viz=stream&from_ts=1731140359632&to_ts=1731143959632&live=false) where those 2 small functions end up representing 6% of the total allocations of the agent.

I was surprised those functions even allocate in the first place, but it makes sense because of the case insensitive nature of the check. To improve a bit the situation, this PR adds some allocation free fast paths, checking directly for the most common cases (all lower or all upper cases).