### PR TITLE
Add option to obfuscate bind parameter

### DIFF
--- a/obfuscator.go
+++ b/obfuscator.go
@@ -11,6 +11,7 @@ type obfuscatorConfig struct {
 	ReplaceBoolean             bool `json:"replace_boolean"`
 	ReplaceNull                bool `json:"replace_null"`
 	KeepJsonPath               bool `json:"keep_json_path"` // by default, we replace json path with placeholder
+	ReplaceBindParameter       bool `json:"replace_bind_parameter"`
 }
 
 type obfuscatorOption func(*obfuscatorConfig)
@@ -48,6 +49,12 @@ func WithDollarQuotedFunc(dollarQuotedFunc bool) obfuscatorOption {
 func WithKeepJsonPath(keepJsonPath bool) obfuscatorOption {
 	return func(c *obfuscatorConfig) {
 		c.KeepJsonPath = keepJsonPath
+	}
+}
+
+func WithReplaceBindParameter(replaceBindParameter bool) obfuscatorOption {
+	return func(c *obfuscatorConfig) {
+		c.ReplaceBindParameter = replaceBindParameter
 	}
 }
 
@@ -124,6 +131,12 @@ func (o *Obfuscator) ObfuscateTokenValue(token Token, lastToken Token, lexerOpts
 		return StringPlaceholder
 	case POSITIONAL_PARAMETER:
 		if o.config.ReplacePositionalParameter {
+			return StringPlaceholder
+		} else {
+			return token.Value
+		}
+	case BIND_PARAMETER:
+		if o.config.ReplaceBindParameter {
 			return StringPlaceholder
 		} else {
 			return token.Value

--- a/obfuscator_test.go
+++ b/obfuscator_test.go
@@ -17,6 +17,7 @@ func TestObfuscator(t *testing.T) {
 		replaceNull                bool
 		dollarQuotedFunc           bool
 		keepJsonPath               bool
+		replaceBindParameter       bool
 		dbms                       DBMSType
 	}{
 		{
@@ -535,6 +536,16 @@ func TestObfuscator(t *testing.T) {
 			expected:     `SELECT * FROM users where data::jsonb ->> 1`,
 			keepJsonPath: true,
 		},
+		{
+			input:                `SELECT * FROM users where id = @_My_id`,
+			expected:             `SELECT * FROM users where id = @_My_id`,
+			replaceBindParameter: false,
+		},
+		{
+			input:                `SELECT * FROM users where id = @_My_id`,
+			expected:             `SELECT * FROM users where id = ?`,
+			replaceBindParameter: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -546,6 +557,7 @@ func TestObfuscator(t *testing.T) {
 				WithReplaceNull(tt.replaceNull),
 				WithDollarQuotedFunc(tt.dollarQuotedFunc),
 				WithKeepJsonPath(tt.keepJsonPath),
+				WithReplaceBindParameter(tt.replaceBindParameter),
 			)
 			got := obfuscator.Obfuscate(tt.input, WithDBMS(tt.dbms))
 			assert.Equal(t, tt.expected, got)

--- a/sqllexer_test.go
+++ b/sqllexer_test.go
@@ -530,6 +530,27 @@ func TestLexer(t *testing.T) {
 			},
 		},
 		{
+			name:  "select with bind parameter using underscore",
+			input: "SELECT * FROM users where id = @__my_id",
+			expected: []Token{
+				{IDENT, "SELECT"},
+				{WS, " "},
+				{WILDCARD, "*"},
+				{WS, " "},
+				{IDENT, "FROM"},
+				{WS, " "},
+				{IDENT, "users"},
+				{WS, " "},
+				{IDENT, "where"},
+				{WS, " "},
+				{IDENT, "id"},
+				{WS, " "},
+				{OPERATOR, "="},
+				{WS, " "},
+				{BIND_PARAMETER, "@__my_id"},
+			},
+		},
+		{
 			name:  "select with system variable",
 			input: "SELECT @@VERSION AS SqlServerVersion",
 			expected: []Token{

--- a/sqllexer_utils.go
+++ b/sqllexer_utils.go
@@ -186,7 +186,7 @@ func isLetter(ch rune) bool {
 }
 
 func isAlphaNumeric(ch rune) bool {
-	return isLetter(ch) || isDigit(ch)
+	return isLetter(ch) || isDigit(ch) || ch == '_'
 }
 
 func isDoubleQuote(ch rune) bool {

--- a/sqllexer_utils.go
+++ b/sqllexer_utils.go
@@ -186,7 +186,7 @@ func isLetter(ch rune) bool {
 }
 
 func isAlphaNumeric(ch rune) bool {
-	return isLetter(ch) || isDigit(ch) || ch == '_'
+	return isLetter(ch) || isDigit(ch)
 }
 
 func isDoubleQuote(ch rune) bool {

--- a/testdata/mssql/select/select-with-bind-parameter.json
+++ b/testdata/mssql/select/select-with-bind-parameter.json
@@ -1,0 +1,17 @@
+{
+    "input": "SELECT[u].[USER_SETTINGS_ID], [u].[CREATED], [u].[CREATED_BY], [u].[FK_APPLICATION_SCOPE_ID], [u].[MODIFIED], [u].[MODIFIED_BY], [u].[PREFERRED_LANGUAGE], [u].[SETTINGS], [u].[USER_NAME], [u].[USER_SECRET], [u].[USER_SECRET_TMP] FROM [USER_SETTING] WHERE [u].[USER_NAME] = @__userName_0;",
+    "outputs": [
+      {
+        "expected": "SELECT [u].[USER_SETTINGS_ID], [u].[CREATED], [u].[CREATED_BY], [u].[FK_APPLICATION_SCOPE_ID], [u].[MODIFIED], [u].[MODIFIED_BY], [u].[PREFERRED_LANGUAGE], [u].[SETTINGS], [u].[USER_NAME], [u].[USER_SECRET], [u].[USER_SECRET_TMP] FROM [USER_SETTING] WHERE [u].[USER_NAME] = @__userName_0",
+        "obfuscator_config": {
+            "replace_positional_parameter": false
+        },
+        "normalizer_config": {
+            "keep_sql_alias": true,
+            "remove_space_between_parentheses": true,
+            "keep_identifier_quotation": true
+        }
+      }
+    ]
+  }
+  


### PR DESCRIPTION
This PR adds option to obfuscate bind parameters. It also fixes a tokenization bug when underscore is used in bind parameters.