### PR TITLE
Alternative SQL Server name (sql-server)

### DIFF
--- a/obfuscate_and_normalize_test.go
+++ b/obfuscate_and_normalize_test.go
@@ -196,6 +196,21 @@ multiline comment */
 			},
 		},
 		{
+			// [] quoted table name
+			input:    `SELECT * FROM [public].[users] WHERE id = 1`,
+			expected: `SELECT * FROM public.users WHERE id = ?`,
+			statementMetadata: StatementMetadata{
+				Tables:     []string{"public.users"},
+				Comments:   []string{},
+				Commands:   []string{"SELECT"},
+				Procedures: []string{},
+				Size:       18,
+			},
+			lexerOpts: []lexerOption{
+				WithDBMS(DBMSSQLServerAlias1),
+			},
+		},
+		{
 			input:    `CREATE PROCEDURE TestProc AS SELECT * FROM users`,
 			expected: `CREATE PROCEDURE TestProc AS SELECT * FROM users`,
 			statementMetadata: StatementMetadata{

--- a/sqllexer.go
+++ b/sqllexer.go
@@ -40,6 +40,7 @@ type LexerConfig struct {
 type lexerOption func(*LexerConfig)
 
 func WithDBMS(dbms DBMSType) lexerOption {
+	dbms = getDBMSFromAlias(dbms)
 	return func(c *LexerConfig) {
 		c.DBMS = dbms
 	}

--- a/sqllexer_utils.go
+++ b/sqllexer_utils.go
@@ -9,7 +9,8 @@ type DBMSType string
 
 const (
 	// DBMSSQLServer is a MS SQL
-	DBMSSQLServer DBMSType = "mssql"
+	DBMSSQLServer       DBMSType = "mssql"
+	DBMSSQLServerAlias1 DBMSType = "sql-server"
 	// DBMSPostgres is a PostgreSQL Server
 	DBMSPostgres DBMSType = "postgresql"
 	// DBMSMySQL is a MySQL Server
@@ -19,6 +20,14 @@ const (
 	// DBMSSnowflake is a Snowflake Server
 	DBMSSnowflake DBMSType = "snowflake"
 )
+
+func getDBMSFromAlias(alias DBMSType) DBMSType {
+	switch alias {
+	case DBMSSQLServerAlias1:
+		return DBMSSQLServer
+	}
+	return alias
+}
 
 func PrecomputeCaseInsensitiveKeys[T any](input map[string]T) map[string]T {
 	result := make(map[string]T, len(input)*3)


### PR DESCRIPTION
Add an alternative name for SQL Server DBMS. `sql-server` is used by .Net tracer.