### PR TITLE
Trim leading expression in parantheses

### DIFF
--- a/normalizer.go
+++ b/normalizer.go
@@ -1,8 +1,11 @@
 package sqllexer
 
 import (
+	"regexp"
 	"strings"
 )
+
+var leadingBracketsRegex = regexp.MustCompile(`^\s*\(.*?\)\s*(\S+)`)
 
 type normalizerConfig struct {
 	// CollectTables specifies whether the normalizer should also extract the table names that a query addresses
@@ -322,6 +325,7 @@ func (n *Normalizer) trimNormalizedSQL(normalizedSQL string) string {
 		// Remove trailing semicolon
 		normalizedSQL = strings.TrimSuffix(normalizedSQL, ";")
 	}
+	normalizedSQL = leadingBracketsRegex.ReplaceAllString(normalizedSQL, "$1")
 	return strings.TrimSpace(normalizedSQL)
 }
 

--- a/normalizer_test.go
+++ b/normalizer_test.go
@@ -887,6 +887,27 @@ func TestNormalizeDeobfuscatedSQL(t *testing.T) {
 				WithDBMS(DBMSSQLServer),
 			},
 		},
+		{
+			input:    `( @p1 bigint ) SELECT * from dbm_user as prepared_user WHERE id = @p1`,
+			expected: `SELECT * from dbm_user as prepared_user WHERE id = @p1`,
+			statementMetadata: StatementMetadata{
+				Tables:     []string{`dbm_user`},
+				Comments:   []string{},
+				Commands:   []string{"SELECT"},
+				Procedures: []string{},
+				Size:       14,
+			},
+			normalizationConfig: &normalizerConfig{
+				CollectComments:         true,
+				CollectCommands:         true,
+				CollectTables:           true,
+				KeepSQLAlias:            true,
+				KeepIdentifierQuotation: true,
+			},
+			lexerOptions: []lexerOption{
+				WithDBMS(DBMSSQLServer),
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/obfuscate_and_normalize.go
+++ b/obfuscate_and_normalize.go
@@ -21,17 +21,18 @@ func ObfuscateAndNormalize(input string, obfuscator *Obfuscator, normalizer *Nor
 
 	var lastToken Token // The last token that is not whitespace or comment
 	var groupablePlaceholder groupablePlaceholder
+	var headState headState
 
 	ctes := make(map[string]bool) // Holds the CTEs that are currently being processed
 
 	for {
 		token := lexer.Scan()
+		token.Value = obfuscator.ObfuscateTokenValue(token, lastToken, lexerOpts...)
+		normalizer.collectMetadata(&token, &lastToken, statementMetadata, ctes)
+		normalizer.normalizeSQL(&token, &lastToken, &normalizedSQLBuilder, &groupablePlaceholder, &headState, lexerOpts...)
 		if token.Type == EOF {
 			break
 		}
-		token.Value = obfuscator.ObfuscateTokenValue(token, lastToken, lexerOpts...)
-		normalizer.collectMetadata(&token, &lastToken, statementMetadata, ctes)
-		normalizer.normalizeSQL(&token, &lastToken, &normalizedSQLBuilder, &groupablePlaceholder, lexerOpts...)
 	}
 
 	normalizedSQL = normalizedSQLBuilder.String()

--- a/obfuscate_and_normalize_test.go
+++ b/obfuscate_and_normalize_test.go
@@ -458,6 +458,20 @@ multiline comment */
 			},
 		},
 		{
+			input:    `/*dddbs='mydb',ddpv='1.2.3'*/ ( @p1 bigint ) SELECT * from dbm_user WHERE id = @p1`,
+			expected: `SELECT * from dbm_user WHERE id = @p1`,
+			statementMetadata: StatementMetadata{
+				Tables:     []string{"dbm_user"},
+				Comments:   []string{"/*dddbs='mydb',ddpv='1.2.3'*/"},
+				Commands:   []string{"SELECT"},
+				Procedures: []string{},
+				Size:       43,
+			},
+			lexerOpts: []lexerOption{
+				WithDBMS(DBMSSQLServer),
+			},
+		},
+		{
 			input:    `SELECT pk, updatedAt, createdAt, name, description, isAutoCreated, autoCreatedFeaturePk FROM FeatureStrategyGroup WHERE FeatureStrategyGroup.autoCreatedFeaturePk IN ( ? )`,
 			expected: `SELECT pk, updatedAt, createdAt, name, description, isAutoCreated, autoCreatedFeaturePk FROM FeatureStrategyGroup WHERE FeatureStrategyGroup.autoCreatedFeaturePk IN ( ? )`,
 			statementMetadata: StatementMetadata{


### PR DESCRIPTION
### Goal

Remove the leading expression in brackets.

### Why It Matters

In query metrics, the leading bracketed expression is removed, but in activity samples and deadlocks, the full statement appears.

Example:

Issued Statement:

`( @p1 bigint ) SELECT * FROM dbm_user AS prepared_user WHERE id = @p1`
In Query Metrics:

`SELECT * FROM dbm_user AS prepared_user WHERE id = @p1`

In Activity Samples & Deadlocks:

`( @p1 bigint ) SELECT * FROM dbm_user AS prepared_user WHERE id = @p1`

This mismatch prevents linking query metrics to activity samples and deadlocks.