### PR TITLE
Fix infinite loop when tokenizer encounters unknown tokens

### DIFF
--- a/normalizer_test.go
+++ b/normalizer_test.go
@@ -1216,7 +1216,7 @@ func ExampleNormalizer() {
 	fmt.Println(normalizedSQL)
 	fmt.Println(statementMetadata)
 	// Output: SELECT * FROM users WHERE id in ( ? )
-	// &{34 [users] [/* this is a comment */] [SELECT] [] map[users:{}] map[/* this is a comment */:{}] map[SELECT:{}] map[]}
+	// &{34 [users] [/* this is a comment */] [SELECT] []}
 }
 
 func assertStatementMetadataEqual(t *testing.T, expected, actual *StatementMetadata) {

--- a/obfuscate_and_normalize.go
+++ b/obfuscate_and_normalize.go
@@ -6,23 +6,33 @@ import "strings"
 // This function is a convenience function that combines the Obfuscator and Normalizer in one pass
 func ObfuscateAndNormalize(input string, obfuscator *Obfuscator, normalizer *Normalizer, lexerOpts ...lexerOption) (normalizedSQL string, statementMetadata *StatementMetadata, err error) {
 	lexer := New(input, lexerOpts...)
-	normalizedSQLBuilder := new(strings.Builder)
+	var normalizedSQLBuilder strings.Builder
 	normalizedSQLBuilder.Grow(len(input))
 
-	// Always allocate metadata for backward compatibility
-	statementMetadata = statementMetadataPool.Get().(*StatementMetadata)
-	statementMetadata.reset()
-	defer statementMetadataPool.Put(statementMetadata)
+	meta := &metadataSet{
+		tablesSet:     map[string]struct{}{},
+		commentsSet:   map[string]struct{}{},
+		commandsSet:   map[string]struct{}{},
+		proceduresSet: map[string]struct{}{},
+	}
+
+	statementMetadata = &StatementMetadata{
+		Tables:     []string{},
+		Comments:   []string{},
+		Commands:   []string{},
+		Procedures: []string{},
+	}
 
 	obfuscate := func(token *Token, lastValueToken *LastValueToken) {
 		obfuscator.ObfuscateTokenValue(token, lastValueToken, lexerOpts...)
 	}
 
 	// Pass obfuscation as the pre-process step
-	if err = normalizer.normalizeToken(lexer, normalizedSQLBuilder, statementMetadata, obfuscate, lexerOpts...); err != nil {
+	if err = normalizer.normalizeToken(lexer, &normalizedSQLBuilder, meta, statementMetadata, obfuscate, lexerOpts...); err != nil {
 		return "", nil, err
 	}
 
 	normalizedSQL = normalizedSQLBuilder.String()
+	statementMetadata.Size = meta.size
 	return normalizer.trimNormalizedSQL(normalizedSQL), statementMetadata, nil
 }

--- a/obfuscator.go
+++ b/obfuscator.go
@@ -82,7 +82,7 @@ const (
 // Obfuscate takes an input SQL string and returns an obfuscated SQL string.
 // The obfuscator replaces all literal values with a single placeholder
 func (o *Obfuscator) Obfuscate(input string, lexerOpts ...lexerOption) string {
-	var obfuscatedSQL = new(strings.Builder)
+	var obfuscatedSQL strings.Builder
 	obfuscatedSQL.Grow(len(input))
 
 	lexer := New(
@@ -118,7 +118,7 @@ func (o *Obfuscator) ObfuscateTokenValue(token *Token, lastValueToken *LastValue
 		if o.config.DollarQuotedFunc {
 			// obfuscate the content of dollar quoted function
 			quotedFunc := token.Value[6 : len(token.Value)-6] // remove the $func$ prefix and suffix
-			obfuscatedDollarQuotedFunc := new(strings.Builder)
+			var obfuscatedDollarQuotedFunc strings.Builder
 			obfuscatedDollarQuotedFunc.Grow(len(quotedFunc) + 12)
 			obfuscatedDollarQuotedFunc.WriteString("$func$")
 			obfuscatedDollarQuotedFunc.WriteString(o.Obfuscate(quotedFunc, lexerOpts...))

--- a/sqllexer_test.go
+++ b/sqllexer_test.go
@@ -959,6 +959,24 @@ here */`,
 				{PUNCTUATION, ")"},
 			},
 		},
+		{
+			name:  "escape character",
+			input: `SELECT E'\c'`,
+			expected: []TokenSpec{
+				{COMMAND, "SELECT"},
+				{SPACE, " "},
+				{IDENT, "E"},
+				{STRING, `'\c'`},
+			},
+		},
+		{
+			name:  "unknown character",
+			input: `\c`, // \c is a psql command but not a valid postgres sql
+			expected: []TokenSpec{
+				{UNKNOWN, `\`},
+				{IDENT, "c"},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/sqllexer_utils.go
+++ b/sqllexer_utils.go
@@ -222,7 +222,7 @@ var keywordRoot = buildCombinedTrie()
 // TODO: Optimize these functions to work with rune positions instead of string operations
 // They are currently used by obfuscator and normalizer, which we'll optimize later
 func replaceDigits(token *Token, placeholder string) string {
-	var replacedToken = new(strings.Builder)
+	var replacedToken strings.Builder
 	replacedToken.Grow(len(token.Value))
 
 	start := 0
@@ -247,7 +247,7 @@ func replaceDigits(token *Token, placeholder string) string {
 }
 
 func trimQuotes(token *Token) string {
-	var trimmedToken = new(strings.Builder)
+	var trimmedToken strings.Builder
 	trimmedToken.Grow(len(token.Value) - len(token.quotes))
 
 	start := 0


### PR DESCRIPTION
This PR 
- fixes a bug that causes infinite loop when tokenizer encounters unknown tokens
- addresses race conditions caused by using `sync.pool` in `StatementMetadata`. `*StatementMetadata` returned by normalizer can be reset and put back to the pool before it's referenced. 