### PR TITLE
Run obfuscator from CLI.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,50 @@
+.PHONY: build clean install test help
+
+# Binary name
+BINARY_NAME=sqllexer
+
+# Build directory
+BUILD_DIR=bin
+
+# Default target
+all: build
+
+# Build the binary
+build:
+	@echo "Building $(BINARY_NAME)..."
+	@mkdir -p $(BUILD_DIR)
+	go build -o $(BUILD_DIR)/$(BINARY_NAME) ./cmd/sqllexer
+
+# Install the binary to GOPATH/bin
+install: build
+	@echo "Installing $(BINARY_NAME)..."
+	cp $(BUILD_DIR)/$(BINARY_NAME) $(shell go env GOPATH)/bin/
+
+# Run tests
+test:
+	@echo "Running tests..."
+	go test -v ./...
+
+# Run benchmarks
+bench:
+	@echo "Running benchmarks..."
+	go test -bench=. -benchmem ./...
+
+# Clean build artifacts
+clean:
+	@echo "Cleaning build artifacts..."
+	rm -rf $(BUILD_DIR)
+
+# Show help
+help:
+	@echo "Available targets:"
+	@echo "  build       - Build the binary for current platform"
+	@echo "  build-all   - Build for Linux, macOS, and Windows"
+	@echo "  build-linux - Build for Linux"
+	@echo "  build-darwin- Build for macOS (Intel and Apple Silicon)"
+	@echo "  build-windows - Build for Windows"
+	@echo "  install     - Install binary to GOPATH/bin"
+	@echo "  test        - Run tests"
+	@echo "  bench       - Run benchmarks"
+	@echo "  clean       - Clean build artifacts"
+	@echo "  help        - Show this help message" 

--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,6 @@ clean:
 help:
 	@echo "Available targets:"
 	@echo "  build       - Build the binary for current platform"
-	@echo "  build-all   - Build for Linux, macOS, and Windows"
-	@echo "  build-linux - Build for Linux"
-	@echo "  build-darwin- Build for macOS (Intel and Apple Silicon)"
-	@echo "  build-windows - Build for Windows"
 	@echo "  install     - Install binary to GOPATH/bin"
 	@echo "  test        - Run tests"
 	@echo "  bench       - Run benchmarks"

--- a/README.md
+++ b/README.md
@@ -13,8 +13,24 @@ This repository contains a hand written SQL Lexer that tokenizes SQL queries wit
 
 ## Installation
 
+### As a Library
+
 ```bash
 go get github.com/DataDog/go-sqllexer
+```
+
+### As a Command-Line Tool
+
+```bash
+# Clone the repository
+git clone https://github.com/DataDog/go-sqllexer.git
+cd go-sqllexer
+
+# Build the binary
+make build
+
+# Or install directly to your PATH
+make install
 ```
 
 ## Usage
@@ -75,6 +91,45 @@ func main() {
     fmt.Println(normalized)
 }
 ```
+
+## Command-Line Usage
+
+The `sqllexer` binary provides a command-line interface for all the library functionality:
+
+```bash
+# Show help
+sqllexer -help
+
+# Obfuscate SQL from stdin
+echo "SELECT * FROM users WHERE id = 1" | sqllexer
+
+# Obfuscate SQL from file
+sqllexer -input query.sql -output obfuscated.sql
+
+# Normalize SQL for PostgreSQL
+sqllexer -mode normalize -dbms postgresql -input query.sql
+
+# Tokenize SQL
+sqllexer -mode tokenize -input query.sql
+
+# Obfuscate with custom options
+sqllexer -replace-digits=false -keep-json-path=true -input query.sql
+```
+
+### Available Modes
+
+- **obfuscate** (default): Replace sensitive data with placeholders
+- **normalize**: Normalize SQL queries for consistent formatting
+- **tokenize**: Show all tokens in the SQL query
+
+### Database Support
+
+Use the `-dbms` flag to specify the database type:
+- `mssql` - Microsoft SQL Server
+- `postgresql` - PostgreSQL
+- `mysql` - MySQL
+- `oracle` - Oracle
+- `snowflake` - Snowflake
 
 ## Testing
 

--- a/cmd/sqllexer/main.go
+++ b/cmd/sqllexer/main.go
@@ -160,6 +160,9 @@ func obfuscateAndNormalizeSQL(input, dbms string, replaceDigits, replaceBoolean,
 		sqllexer.WithCollectCommands(collectCommands),
 		sqllexer.WithCollectTables(collectTables),
 		sqllexer.WithKeepSQLAlias(keepSQLAlias),
+
+		// TODO: Make config param
+		sqllexer.WithKeepIdentifierQuotation(true),
 	)
 
 	result, _, err := sqllexer.ObfuscateAndNormalize(input, obfuscator, normalizer, sqllexer.WithDBMS(sqllexer.DBMSType(dbms)))
@@ -180,7 +183,7 @@ func tokenizeSQL(input, dbms string) (string, error) {
 		if token.Type == sqllexer.EOF {
 			break
 		}
-		result.WriteString(fmt.Sprintf("%s\n", token))
+		result.WriteString(fmt.Sprintf("%s\n", token.Value))
 	}
 
 	return result.String(), nil
@@ -233,6 +236,5 @@ Examples:
   sqllexer -mode tokenize -input query.sql
 
   # Obfuscate with custom options
-  sqllexer -replace-digits=false -keep-json-path=true -input query.sql
-`)
+  sqllexer -replace-digits=false -keep-json-path=true -input query.sql`)
 }

--- a/cmd/sqllexer/main.go
+++ b/cmd/sqllexer/main.go
@@ -167,23 +167,19 @@ func obfuscateAndNormalizeSQL(input, dbms string, replaceDigits, replaceBoolean,
 }
 
 func tokenizeSQL(input, dbms string) (string, error) {
+	var lexer *sqllexer.Lexer
 	if dbms != "" {
-		lexer := sqllexer.New(input, sqllexer.WithDBMS(sqllexer.DBMSType(dbms)))
-		tokens := lexer.ScanAll()
-
-		var result strings.Builder
-		for _, token := range tokens {
-			result.WriteString(fmt.Sprintf("%s\n", token))
-		}
-
-		return result.String(), nil
+		lexer = sqllexer.New(input, sqllexer.WithDBMS(sqllexer.DBMSType(dbms)))
+	} else {
+		lexer = sqllexer.New(input)
 	}
 
-	lexer := sqllexer.New(input)
-	tokens := lexer.ScanAll()
-
 	var result strings.Builder
-	for _, token := range tokens {
+	for {
+		token := lexer.Scan()
+		if token.Type == sqllexer.EOF {
+			break
+		}
 		result.WriteString(fmt.Sprintf("%s\n", token))
 	}
 
@@ -197,7 +193,7 @@ Usage: sqllexer [flags]
 
 Flags:
   -mode string
-        Operation mode: obfuscate, normalize, tokenize (default "obfuscate")
+        Operation mode: obfuscate, normalize, tokenize, obfuscate_and_normalize (default "obfuscate_and_normalize")
   -input string
         Input file (default: stdin)
   -output string

--- a/cmd/sqllexer/main.go
+++ b/cmd/sqllexer/main.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/DataDog/go-sqllexer"
+)
+
+func main() {
+	var (
+		mode            = flag.String("mode", "obfuscate", "Operation mode: obfuscate, normalize, tokenize")
+		inputFile       = flag.String("input", "", "Input file (default: stdin)")
+		outputFile      = flag.String("output", "", "Output file (default: stdout)")
+		dbms            = flag.String("dbms", "", "Database type: mssql, postgresql, mysql, oracle, snowflake")
+		replaceDigits   = flag.Bool("replace-digits", true, "Replace digits with placeholders")
+		replaceBoolean  = flag.Bool("replace-boolean", true, "Replace boolean values with placeholders")
+		replaceNull     = flag.Bool("replace-null", true, "Replace null values with placeholders")
+		keepJsonPath    = flag.Bool("keep-json-path", false, "Keep JSON path expressions")
+		collectComments = flag.Bool("collect-comments", true, "Collect comments during normalization")
+		collectCommands = flag.Bool("collect-commands", true, "Collect commands during normalization")
+		collectTables   = flag.Bool("collect-tables", true, "Collect table names during normalization")
+		keepSQLAlias    = flag.Bool("keep-sql-alias", false, "Keep SQL aliases during normalization")
+		help            = flag.Bool("help", false, "Show help message")
+	)
+
+	flag.Parse()
+
+	if *help {
+		printHelp()
+		return
+	}
+
+	// Read input
+	input, err := readInput(*inputFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading input: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Process based on mode
+	var result string
+	switch *mode {
+	case "obfuscate":
+		result, err = obfuscateSQL(input, *dbms, *replaceDigits, *replaceBoolean, *replaceNull, *keepJsonPath)
+	case "normalize":
+		result, err = normalizeSQL(input, *dbms, *collectComments, *collectCommands, *collectTables, *keepSQLAlias)
+	case "tokenize":
+		result, err = tokenizeSQL(input, *dbms)
+	default:
+		fmt.Fprintf(os.Stderr, "Invalid mode: %s. Use -help for usage information.\n", *mode)
+		os.Exit(1)
+	}
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error processing SQL: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Write output
+	err = writeOutput(result, *outputFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error writing output: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func readInput(inputFile string) (string, error) {
+	var reader io.Reader
+	if inputFile == "" {
+		reader = os.Stdin
+	} else {
+		file, err := os.Open(inputFile)
+		if err != nil {
+			return "", err
+		}
+		defer file.Close()
+		reader = file
+	}
+
+	scanner := bufio.NewScanner(reader)
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+
+	return strings.Join(lines, "\n"), nil
+}
+
+func writeOutput(result, outputFile string) error {
+	if outputFile == "" {
+		fmt.Print(result)
+		return nil
+	}
+
+	file, err := os.Create(outputFile)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = file.WriteString(result)
+	return err
+}
+
+func obfuscateSQL(input, dbms string, replaceDigits, replaceBoolean, replaceNull, keepJsonPath bool) (string, error) {
+	obfuscator := sqllexer.NewObfuscator(
+		sqllexer.WithReplaceDigits(replaceDigits),
+		sqllexer.WithReplaceBoolean(replaceBoolean),
+		sqllexer.WithReplaceNull(replaceNull),
+		sqllexer.WithKeepJsonPath(keepJsonPath),
+	)
+
+	if dbms != "" {
+		result := obfuscator.Obfuscate(input, sqllexer.WithDBMS(sqllexer.DBMSType(dbms)))
+		return result, nil
+	}
+
+	result := obfuscator.Obfuscate(input)
+	return result, nil
+}
+
+func normalizeSQL(input, dbms string, collectComments, collectCommands, collectTables, keepSQLAlias bool) (string, error) {
+	normalizer := sqllexer.NewNormalizer(
+		sqllexer.WithCollectComments(collectComments),
+		sqllexer.WithCollectCommands(collectCommands),
+		sqllexer.WithCollectTables(collectTables),
+		sqllexer.WithKeepSQLAlias(keepSQLAlias),
+	)
+
+	if dbms != "" {
+		result, _, err := normalizer.Normalize(input, sqllexer.WithDBMS(sqllexer.DBMSType(dbms)))
+		return result, err
+	}
+
+	result, _, err := normalizer.Normalize(input)
+	return result, err
+}
+
+func tokenizeSQL(input, dbms string) (string, error) {
+	if dbms != "" {
+		lexer := sqllexer.New(input, sqllexer.WithDBMS(sqllexer.DBMSType(dbms)))
+		tokens := lexer.ScanAll()
+
+		var result strings.Builder
+		for _, token := range tokens {
+			result.WriteString(fmt.Sprintf("%s\n", token))
+		}
+
+		return result.String(), nil
+	}
+
+	lexer := sqllexer.New(input)
+	tokens := lexer.ScanAll()
+
+	var result strings.Builder
+	for _, token := range tokens {
+		result.WriteString(fmt.Sprintf("%s\n", token))
+	}
+
+	return result.String(), nil
+}
+
+func printHelp() {
+	fmt.Println(`SQL Lexer CLI Tool
+
+Usage: sqllexer [flags]
+
+Flags:
+  -mode string
+        Operation mode: obfuscate, normalize, tokenize (default "obfuscate")
+  -input string
+        Input file (default: stdin)
+  -output string
+        Output file (default: stdout)
+  -dbms string
+        Database type: mssql, postgresql, mysql, oracle, snowflake
+  -replace-digits
+        Replace digits with placeholders (default true)
+  -replace-boolean
+        Replace boolean values with placeholders (default true)
+  -replace-null
+        Replace null values with placeholders (default true)
+  -keep-json-path
+        Keep JSON path expressions (default false)
+  -collect-comments
+        Collect comments during normalization (default true)
+  -collect-commands
+        Collect commands during normalization (default true)
+  -collect-tables
+        Collect table names during normalization (default true)
+  -keep-sql-alias
+        Keep SQL aliases during normalization (default false)
+  -help
+        Show this help message
+
+Examples:
+  # Obfuscate SQL from stdin
+  echo "SELECT * FROM users WHERE id = 1" | sqllexer
+
+  # Obfuscate SQL from file
+  sqllexer -input query.sql -output obfuscated.sql
+
+  # Normalize SQL for PostgreSQL
+  sqllexer -mode normalize -dbms postgresql -input query.sql
+
+  # Tokenize SQL
+  sqllexer -mode tokenize -input query.sql
+
+  # Obfuscate with custom options
+  sqllexer -replace-digits=false -keep-json-path=true -input query.sql
+`)
+}


### PR DESCRIPTION
It would be helpful to debug the obfuscator output when triaging issues. Rather than write up a new test case, a CLI wrapper allows us to test arbitrary queries and config settings. It also allows the support team to run the obfuscator without writing code.