### PR TITLE
[DBMON-5792] Fix handling mysql double quoted string literal obfuscation

### DIFF
--- a/obfuscate_and_normalize_test.go
+++ b/obfuscate_and_normalize_test.go
@@ -92,7 +92,7 @@ func TestObfuscationAndNormalization(t *testing.T) {
 		},
 		{
 			input: `
-			/* this is a 
+			/* this is a ` + `
 multiline comment */
 			SELECT * FROM users /* comment comment */ WHERE id = 'XXX'
 			-- this is another comment
@@ -571,6 +571,20 @@ multiline comment */
 				Commands:   []string{"SELECT"},
 				Procedures: []string{},
 				Size:       14,
+			},
+			lexerOpts: []lexerOption{
+				WithDBMS(DBMSMySQL),
+			},
+		},
+		{
+			input:    `select * from dbmorders.dbm_user where nickname = "foo";`,
+			expected: `select * from dbmorders.dbm_user where nickname = ?`,
+			statementMetadata: StatementMetadata{
+				Tables:     []string{"dbmorders.dbm_user"},
+				Comments:   []string{},
+				Commands:   []string{"SELECT"},
+				Procedures: []string{},
+				Size:       24,
 			},
 			lexerOpts: []lexerOption{
 				WithDBMS(DBMSMySQL),

--- a/sqllexer.go
+++ b/sqllexer.go
@@ -114,9 +114,13 @@ func (s *Lexer) Scan() *Token {
 	case isLetter(ch):
 		return s.scanIdentifier(ch)
 	case isDoubleQuote(ch):
+		// MySQL by default (without ANSI_QUOTES mode) treats double quotes as string literals
+		if s.config.DBMS == DBMSMySQL {
+			return s.scanStringWithDelimiter('"')
+		}
 		return s.scanDoubleQuotedIdentifier('"')
 	case isSingleQuote(ch):
-		return s.scanString()
+		return s.scanStringWithDelimiter('\'')
 	case isSingleLineComment(ch, s.lookAhead(1)):
 		return s.scanSingleLineComment(ch)
 	case isMultiLineComment(ch, s.lookAhead(1)):
@@ -312,7 +316,7 @@ func (s *Lexer) scanOctalNumber() *Token {
 	return s.emit(NUMBER)
 }
 
-func (s *Lexer) scanString() *Token {
+func (s *Lexer) scanStringWithDelimiter(delimiter rune) *Token {
 	s.start = s.cursor
 	escaped := false
 	escapedQuote := false
@@ -322,7 +326,7 @@ func (s *Lexer) scanString() *Token {
 	for ; !isEOF(ch); ch = s.next() {
 		if escaped {
 			escaped = false
-			escapedQuote = ch == '\''
+			escapedQuote = ch == delimiter
 			continue
 		}
 
@@ -331,7 +335,7 @@ func (s *Lexer) scanString() *Token {
 			continue
 		}
 
-		if ch == '\'' {
+		if ch == delimiter {
 			s.next() // consume the closing quote
 			return s.emit(STRING)
 		}


### PR DESCRIPTION
Mysql by default allows for single or double quotes to be used as [string literals](https://dev.mysql.com/doc/refman/8.4/en/string-literals.html). This change fixes an issue where we're incorrectly handling obfuscating queries that use double quoted string literals. This isn't a problem in other DBMS's we support like Postgres, Oracle, SqlServer