### PR TITLE
Fix a normalization bug in SqlServer parameterized queries

### DIFF
--- a/obfuscate_and_normalize_test.go
+++ b/obfuscate_and_normalize_test.go
@@ -548,6 +548,20 @@ multiline comment */
 			},
 		},
 		{
+			input:    `( @p1 varchar(50) ) SELECT * from dbm_user WHERE name = @p1`,
+			expected: `SELECT * from dbm_user WHERE name = @p1`,
+			statementMetadata: StatementMetadata{
+				Tables:     []string{"dbm_user"},
+				Comments:   []string{},
+				Commands:   []string{"SELECT"},
+				Procedures: []string{},
+				Size:       14,
+			},
+			lexerOpts: []lexerOption{
+				WithDBMS(DBMSSQLServer),
+			},
+		},
+		{
 			input:    `SELECT pk, updatedAt, createdAt, name, description, isAutoCreated, autoCreatedFeaturePk FROM FeatureStrategyGroup WHERE FeatureStrategyGroup.autoCreatedFeaturePk IN ( ? )`,
 			expected: `SELECT pk, updatedAt, createdAt, name, description, isAutoCreated, autoCreatedFeaturePk FROM FeatureStrategyGroup WHERE FeatureStrategyGroup.autoCreatedFeaturePk IN ( ? )`,
 			statementMetadata: StatementMetadata{


### PR DESCRIPTION
We added support for normalizing parameter type definitions in SqlServer prepared statements with parameters in https://github.com/DataDog/go-sqllexer/pull/50. The current implementation aborts early on the first  closed parenthesis `)` seen which causes an issue with complex datatypes like `varchar(50)`. This change keeps track of parenthsis depth so that we can properly mark the end

v0.1.9
```bash
echo "( @p1 varchar(50) ) SELECT * from dbm_user WHERE name = @p1" | ./bin/sqllexer -dbms mssql
) SELECT * from dbm_user WHERE name = @p1
```

After this fix
```bash
echo "( @p1 varchar(50) ) SELECT * from dbm_user WHERE name = @p1" | ./bin/sqllexer -dbms mssql
SELECT * from dbm_user WHERE name = @p1
```