### PR TITLE
Fix -with-metadata cli flag escaping special characters

### DIFF
--- a/cmd/sqllexer/main.go
+++ b/cmd/sqllexer/main.go
@@ -126,12 +126,18 @@ func formatWithMetadata(sql string, metadata *sqllexer.StatementMetadata) (strin
 		Metadata: metadata,
 	}
 
-	jsonBytes, err := json.MarshalIndent(output, "", "  ")
-	if err != nil {
+	var buf strings.Builder
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+
+	if err := encoder.Encode(output); err != nil {
 		return "", fmt.Errorf("failed to marshal output: %w", err)
 	}
 
-	return string(jsonBytes), nil
+	// Encoder.Encode adds a trailing newline, remove it for consistency
+	result := buf.String()
+	return strings.TrimSuffix(result, "\n"), nil
 }
 
 func obfuscateSQL(input, dbms string, replaceDigits, replaceBoolean, replaceNull, keepJsonPath bool) (string, error) {


### PR DESCRIPTION
This fixes an issue where running the cli using -with-metadata flag will escape characters like `<`, `>`, and `&`. This now aligns functionality when a query is ran without the flag.

Before
```bash
% q="select * from foo where data >  1;"               
% echo "$q" | ./bin/sqllexer                           
select * from foo where data > ?

% echo "$q" | ./bin/sqllexer -with-metadata
{
  "sql": "select * from foo where data \u003e ?",
  "metadata": {
    "size": 9,
    "tables": [
      "foo"
    ],
    "comments": [],
    "commands": [
      "SELECT"
    ],
    "procedures": []
  }
}
```

After fix
```bash
% echo "$q" | ./bin/sqllexer -with-metadata
{
  "sql": "select * from foo where data > ?",
  "metadata": {
    "size": 9,
    "tables": [
      "foo"
    ],
    "comments": [],
    "commands": [
      "SELECT"
    ],
    "procedures": []
  }
}

```