### PR TITLE
fix(normalizer): preserve bracket-quoted identifiers containing spaces

### DIFF
--- a/normalizer.go
+++ b/normalizer.go
@@ -408,6 +408,11 @@ func (n *Normalizer) shouldStripIdentifierQuotes(token *Token, lastValueToken *L
 	if isAliasContext(lastValueToken) && !token.isSimpleIdentifier {
 		return false
 	}
+	// Bracket-quoted identifiers whose content contains whitespace cannot be
+	// safely unquoted: the stripped form would produce multiple SQL tokens.
+	if strings.ContainsAny(token.Value, " \t\n\r") {
+		return false
+	}
 	return true
 }
 
@@ -467,6 +472,12 @@ func (n *Normalizer) appendSpace(token *Token, lastValueToken *LastValueToken, n
 	}
 
 	if n.config.RemoveSpaceBetweenParentheses && (token.Value == ")" || token.Value == "]") {
+		return
+	}
+
+	// do not add a space between a dot-suffixed identifier and the following identifier,
+	// because the lexer splits e.g. t.[Col] into "t." and "[Col]" as separate tokens
+	if lastValueToken != nil && len(lastValueToken.Value) > 1 && lastValueToken.Value[len(lastValueToken.Value)-1] == '.' && (token.Type == IDENT || token.Type == QUOTED_IDENT) {
 		return
 	}
 

--- a/normalizer_test.go
+++ b/normalizer_test.go
@@ -1042,6 +1042,85 @@ func TestNormalizeDeobfuscatedSQL(t *testing.T) {
 			},
 		},
 		{
+			// simple bracket-quoted column after dot — no space, brackets stripped, metadata on
+			input:    `SELECT t.[SimpleCol] FROM dbo.SomeTable AS t`,
+			expected: `SELECT t.SimpleCol FROM dbo.SomeTable AS t`,
+			statementMetadata: StatementMetadata{
+				Tables:     []string{`dbo.SomeTable`},
+				Comments:   []string{},
+				Commands:   []string{"SELECT"},
+				Procedures: []string{},
+				Size:       19,
+			},
+			normalizationConfig: &normalizerConfig{
+				CollectComments: true,
+				CollectCommands: true,
+				CollectTables:   true,
+				KeepSQLAlias:    true,
+			},
+			lexerOptions: []lexerOption{
+				WithDBMS(DBMSSQLServer),
+			},
+		},
+		{
+			// same as above with all metadata collection disabled — output must be identical
+			input:    `SELECT t.[SimpleCol] FROM dbo.SomeTable AS t`,
+			expected: `SELECT t.SimpleCol FROM dbo.SomeTable AS t`,
+			statementMetadata: StatementMetadata{
+				Tables:     []string{},
+				Comments:   []string{},
+				Commands:   []string{},
+				Procedures: []string{},
+				Size:       0,
+			},
+			normalizationConfig: &normalizerConfig{
+				KeepSQLAlias: true,
+			},
+			lexerOptions: []lexerOption{
+				WithDBMS(DBMSSQLServer),
+			},
+		},
+		{
+			input:    `SELECT t.[Column With Spaces] FROM dbo.SomeTable AS t`,
+			expected: `SELECT t.[Column With Spaces] FROM dbo.SomeTable AS t`,
+			statementMetadata: StatementMetadata{
+				Tables:     []string{`dbo.SomeTable`},
+				Comments:   []string{},
+				Commands:   []string{"SELECT"},
+				Procedures: []string{},
+				Size:       19,
+			},
+			normalizationConfig: &normalizerConfig{
+				CollectComments: true,
+				CollectCommands: true,
+				CollectTables:   true,
+				KeepSQLAlias:    true,
+			},
+			lexerOptions: []lexerOption{
+				WithDBMS(DBMSSQLServer),
+			},
+		},
+		{
+			input:    `SELECT [First Name], [Last Name] FROM [My Table]`,
+			expected: `SELECT [First Name], [Last Name] FROM [My Table]`,
+			statementMetadata: StatementMetadata{
+				Tables:     []string{`My Table`},
+				Comments:   []string{},
+				Commands:   []string{"SELECT"},
+				Procedures: []string{},
+				Size:       14,
+			},
+			normalizationConfig: &normalizerConfig{
+				CollectComments: true,
+				CollectCommands: true,
+				CollectTables:   true,
+				KeepSQLAlias:    true,
+			},
+			lexerOptions: []lexerOption{
+				WithDBMS(DBMSSQLServer),
+			},
+		},
+		{
 			input:    `( @p1 bigint ) SELECT * from dbm_user as prepared_user WHERE id = @p1`,
 			expected: `SELECT * from dbm_user as prepared_user WHERE id = @p1`,
 			statementMetadata: StatementMetadata{


### PR DESCRIPTION
## Context

Reported in SDBM-2749: T-SQL queries using bracket-quoted identifiers with spaces in the column name (e.g. `schema.[Column With Spaces]`) were being normalized to invalid SQL. The brackets were stripped, leaving bare spaces in identifier position which breaks query structure.

## What was happening

`shouldStripIdentifierQuotes` only protected non-simple identifiers in alias context. In column/table reference position, brackets were always stripped — including identifiers whose content contains spaces, which cannot appear unquoted in SQL.

A secondary issue: the lexer splits `alias.[Spaced Name]` into two tokens (`alias.` + `[Spaced Name]`), and the normalizer was inserting a space between them, producing `alias. [Spaced Name]` instead of `alias.[Spaced Name]`.

## Fix

1. `shouldStripIdentifierQuotes`: refuse to strip when the raw token value contains whitespace — unquoted, the content would become multiple SQL tokens.
2. `appendSpace`: suppress the inter-token space when the preceding token ends with `.` and the next is a `QUOTED_IDENT`.

Simple identifiers (`[schema]`, `[table]`) and dot-joined multi-part identifiers (`[schema].[table]`) contain no whitespace and continue to be de-bracketed as before.

## Test plan

- [ ] `SELECT t.[Column With Spaces] FROM dbo.SomeTable AS t` → brackets preserved, no spurious space
- [ ] `SELECT [First Name], [Last Name] FROM [My Table]` → all brackets preserved
- [ ] `SELECT * FROM [public].[users]` → still de-bracketed to `public.users` (regression)
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)