### PR TITLE
Update CHANGELOG.md for v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.2.3
+
+### Bug Fixes
+
+- **Preserve bracket-quoted T-SQL identifiers containing spaces** ([#101](https://github.com/DataDog/go-sqllexer/pull/101))
+  Bracket-quoted identifiers whose content contains whitespace (e.g. `[Column With Spaces]`) are no longer de-bracketed during normalization. Stripping the brackets produces bare spaces in identifier position, which breaks query structure. Simple identifiers (`[schema]`, `[table]`) and dot-joined multi-part identifiers (`[schema].[table]`) are unaffected and continue to be de-bracketed as before. A secondary fix suppresses the spurious space that the normalizer was inserting between a dot-suffixed token and the bracket-quoted identifier that follows it (e.g. `t. [Col]` → `t.[Col]`).
+
 ## v0.2.2
 
 ### Bug Fixes


### PR DESCRIPTION
## Summary

- Adds the v0.2.3 section to `CHANGELOG.md` covering #101 (preserve bracket-quoted T-SQL identifiers containing spaces).
- Mirrors the formatting used for v0.2.2 / v0.2.1.

Once #101 merges and this lands, tag `v0.2.3` on the resulting commit (matches the v0.2.2 pattern, which was tagged on its CHANGELOG-update commit).

## Test plan

- [x] No code changes — docs only
- [ ] Visual review of the new section against the established CHANGELOG style

🤖 Generated with [Claude Code](https://claude.com/claude-code)